### PR TITLE
fix: docker-compose fails with multiple merge keys

### DIFF
--- a/development/docker-compose.base.yml
+++ b/development/docker-compose.base.yml
@@ -26,8 +26,9 @@ services:
       timeout: "10s"
       start_period: "120s"
       retries: 3
-    <<: *nautobot-build
-    <<: *nautobot-base
+    <<:
+      - *nautobot-build
+      - *nautobot-base
   worker:
     entrypoint:
       - "sh"


### PR DESCRIPTION
Docker compose no longer allows multiple merge keys in compose files. The YAML spec allows multiple maps to be merged by passing a sequence to the merge (`<<:`) key. This is documented in the
[YAML spec](https://yaml.org/type/merge.html). The behavior change for docker-compose is documented in
[this issue](https://github.com/docker/compose/issues/10411)