### PR TITLE
fix: Fixed broken cable connections

### DIFF
--- a/design_builder/contrib/tests/test_ext.py
+++ b/design_builder/contrib/tests/test_ext.py
@@ -148,6 +148,8 @@ class TestCableConnectionExtension(TestCase):
         interfaces = Interface.objects.all()
         self.assertEqual(2, len(interfaces))
         self.assertEqual(interfaces[0].connected_endpoint, interfaces[1])
+        self.assertIsNotNone(interfaces[0]._path_id)  # pylint: disable=protected-access
+        self.assertIsNotNone(interfaces[1]._path_id)  # pylint: disable=protected-access
 
 
 class PrefixExtensionTests(TestCase):

--- a/design_builder/ext.py
+++ b/design_builder/ext.py
@@ -169,7 +169,7 @@ class ReferenceExtension(Extension):
             model_instance = self._env[key]
         except KeyError:
             raise DesignImplementationError(f"No ref named {key} has been saved in the design.")
-        if model_instance.instance:
+        if model_instance.instance and not model_instance.instance._state.adding:  # pylint: disable=protected-access
             model_instance.instance.refresh_from_db()
         if attribute:
             return reduce(getattr, [model_instance.instance, *attribute.split(".")])


### PR DESCRIPTION
The path for cables was partially broken due to the sequence of save -> signal -> update related object. This fix refreshes the related object so that values are not overwritten that were added in the signal handler