### PR TITLE
Update initial state in load_instance get

### DIFF
--- a/nautobot_design_builder/design.py
+++ b/nautobot_design_builder/design.py
@@ -390,6 +390,7 @@ class ModelInstance:  # pylint: disable=too-many-instance-attributes
         query_filter = _map_query_values(self.filter)
         if self.action == self.GET:
             self.instance = self.model_class.objects.get(**query_filter)
+            self._initial_state = serialize_object_v2(self.instance)
             return
 
         if self.action in [self.UPDATE, self.CREATE_OR_UPDATE]:


### PR DESCRIPTION
While working with Andrew, we found that the initial state wasn't getting set in the `_load_instances` when the action was `GET`. 