### PR TITLE
fix: Provides a way to specify save arguments

### DIFF
--- a/docs/admin/release_notes/version_1.1.md
+++ b/docs/admin/release_notes/version_1.1.md
@@ -4,14 +4,16 @@
 
 - 
 
-
 ## [v1.6.0] - 2023-09
 
 ### Added
 
-- Added
+- Added `deferred` attribute to allow deferral of field assignment. See notes in the Changed section.
+
+- Added `model_metadata` attribute to models. At the moment, this provides the ability to specify additional arguments passed to the `save` method of models being updated. The known use case for this is in creating Git repositories in Nautobot 1.x where `trigger_resync` must be `False`. In the future, additional fields will be added to `model_metadata` to provide new functionality.
 
 ### Changed
 
-- Added `deferred` attribute to allow deferral of field assignment.
 - Renamed `nautobot_design_builder.design.Builder` to `nautobot_design_builder.Environment` - aliased original name with deprecation warning.
+
+- Any designs that set `OneToOne` relationships (such as device `primary_ip4`) may now need a `deferred: true` statement in their design for those fields. Previously, `OneToOne` relationships were always deferred and this is usually unnecessary. Any deferrals must now be explicit.

--- a/nautobot_design_builder/tests/test_builder.py
+++ b/nautobot_design_builder/tests/test_builder.py
@@ -124,12 +124,13 @@ def builder_test_case(data_dir):
                     for extension in testcase.get("extensions", []):
                         extensions.append(_load_class(extension))
 
-                    for design in testcase["designs"]:
-                        environment = Environment(extensions=extensions)
-                        commit = design.pop("commit", True)
-                        environment.implement_design(design=design, commit=commit)
-                        if not commit:
-                            roll_back.assert_called()
+                    with self.captureOnCommitCallbacks(execute=True):
+                        for design in testcase["designs"]:
+                            environment = Environment(extensions=extensions)
+                            commit = design.pop("commit", True)
+                            environment.implement_design(design=design, commit=commit)
+                            if not commit:
+                                roll_back.assert_called()
 
                     for index, check in enumerate(testcase.get("checks", [])):
                         for check_name, args in check.items():

--- a/nautobot_design_builder/tests/testdata/nautobot_v1/git_repo.yaml
+++ b/nautobot_design_builder/tests/testdata/nautobot_v1/git_repo.yaml
@@ -1,0 +1,14 @@
+---
+designs:
+  - git_repositories:
+      - model_metadata:
+          save_args:
+            trigger_resync: false
+        name: "backups"
+        remote_url: "https://github.com/nautobot/demo-gc-backups"
+        branch: "main"
+
+checks:
+  - model_exists:
+      model: "nautobot.extras.models.GitRepository"
+      query: {name: "backups"}

--- a/nautobot_design_builder/tests/testdata/nautobot_v2/git_repo.yaml
+++ b/nautobot_design_builder/tests/testdata/nautobot_v2/git_repo.yaml
@@ -1,0 +1,11 @@
+---
+designs:
+  - git_repositories:
+      - name: "backups"
+        remote_url: "https://github.com/nautobot/demo-gc-backups"
+        branch: "main"
+
+checks:
+  - model_exists:
+      model: "nautobot.extras.models.GitRepository"
+      query: {name: "backups"}


### PR DESCRIPTION
This change allows passing arguments to model `save` methods. The specific fix is for creating Git repositories where `trigger_resync=False` must be passed to the `save()` method.

Fixes #39