### PR TITLE
[ltm-1.6] Import mode for existing data

### DIFF
--- a/docs/user/design_lifecycle.md
+++ b/docs/user/design_lifecycle.md
@@ -83,6 +83,8 @@ The decommissioning feature takes into account potential dependencies between de
 
 Once a design deployment is decommissioned, it's still visible in the API/UI to check the history of changes but without any active relationship with Nautobot objects (in a "Decommissioned" status). Once decommissioned, the design deployment can be deleted completely from Nautobot.
 
+There is a decommissioning mode to only remove the design traceability of a design deployment, without actually reverting the state of the objects. Decommissioning, with the `only_traceability` checkbox, is only removing the references but keeping the data.
+
 The decommissioning job outputs a log with all the detailed operation reverting to previous state (i.e., deleting or recovering original data):
 
 ![design-deployment-decommissioning](../images/screenshots/design-deployment-decommissioning.png)

--- a/docs/user/design_lifecycle.md
+++ b/docs/user/design_lifecycle.md
@@ -93,11 +93,20 @@ Design Builder helps in greenfield use cases (i.e., creating a new data from a d
 
 The import logic works like this:
 
-1. If the object that we reference doens't exist, normal design creation logic applies.
+1. If the object that we reference doesn't exist, normal design creation logic applies.
 
 2. If an object that we want to "create" already exists
-   2.1. If it's not owned by another design deployment, we get "full_control" of it.
-   2.2. If it has already an owner, we don't claim ownership of the object, but we still may claim some attributes.
-   2.3 In both cases, the attributes that this design is trying to update are claimed. These attributes can't be claimed by any other design. If so, the import fails pointing to the conflict dependency.
+   2.1. If it's not owned by another design deployment, we get "full_control" of it, and of all the attributes that we define (including the identifiers).
+   2.2. If it's owned, the process fails with an exception because the intention of "create" is to have ownership.
 
-3. The imported changes (attributes) show the same old and new value because we can't infer which was the previous value (in most cases, it would be `null` but we can't be sure).
+3. If an object that we want to "create_or_update" already exists
+   3.1. If it's not owned by another design deployment, we get "full_control" of it, and of all the attributes that we define (including the identifiers).
+   3.2. If it has already an owner, we don't claim ownership of the object, but we still may claim the attributes, except the identifiers.
+
+4. If an object that we want to "update" already exists
+   3.1. There is no claim for full_control ownership.
+   3.2. There is claim for the attributes, except the identifiers.
+
+5. In all cases, the attributes that a design is trying to update are claimed. These attributes can't be claimed by any other design. If so, the import fails pointing to the conflict dependency.
+
+6. The imported changes (attributes) show the same old and new value because we can't infer which was the previous value (in most cases, it would be `null` but we can't be sure).

--- a/docs/user/design_lifecycle.md
+++ b/docs/user/design_lifecycle.md
@@ -86,3 +86,18 @@ Once a design deployment is decommissioned, it's still visible in the API/UI to 
 The decommissioning job outputs a log with all the detailed operation reverting to previous state (i.e., deleting or recovering original data):
 
 ![design-deployment-decommissioning](../images/screenshots/design-deployment-decommissioning.png)
+
+### Design Deployment Import
+
+Design Builder helps in greenfield use cases (i.e., creating a new data from a design) and in brownfield ones too (i.e., importing existing data that are are related to a new deployment). In the "deployment" mode, a Design Deployment tracks all the objects and attributes that are "owned" by it. With the import functionality, orphan objects and attributes will be incorporated to a new Design Deployment as if they have been set by it.
+
+The import logic works like this:
+
+1. If the object that we reference doens't exist, normal design creation logic applies.
+
+2. If an object that we want to "create" already exists
+   2.1. If it's not owned by another design deployment, we get "full_control" of it.
+   2.2. If it has already an owner, we don't claim ownership of the object, but we still may claim some attributes.
+   2.3 In both cases, the attributes that this design is trying to update are claimed. These attributes can't be claimed by any other design. If so, the import fails pointing to the conflict dependency.
+
+3. The imported changes (attributes) show the same old and new value because we can't infer which was the previous value (in most cases, it would be `null` but we can't be sure).

--- a/nautobot_design_builder/design.py
+++ b/nautobot_design_builder/design.py
@@ -43,12 +43,13 @@ class Journal:
     will only be in each of those indices at most once.
     """
 
-    def __init__(self, change_set: models.ChangeSet = None):
+    def __init__(self, change_set: models.ChangeSet = None, import_mode=False):
         """Constructor for Journal object."""
         self.index = set()
         self.created = defaultdict(set)
         self.updated = defaultdict(set)
         self.change_set = change_set
+        self.import_mode = import_mode
 
     def log(self, model: "ModelInstance"):
         """Log that a model has been created or updated.
@@ -59,8 +60,9 @@ class Journal:
         instance = model.instance
         model_type = instance.__class__
         if self.change_set:
-            self.change_set.log(model)
+            self.change_set.log(model, self.import_mode)
 
+        # TODO: CA - I don't understand this
         if instance.pk not in self.index:
             self.index.add(instance.pk)
 
@@ -437,7 +439,6 @@ class ModelInstance:
         self.environment = environment
         self.instance: Model = None
         self.metadata = ModelMetadata(self, **attributes.pop("model_metadata", {}))
-
         self._parent = parent
         self.refresh_custom_relationships()
         self.relationship_manager = relationship_manager
@@ -681,7 +682,11 @@ class Environment(LoggingMixin):
         return object.__new__(cls)
 
     def __init__(
-        self, job_result: JobResult = None, extensions: List[ext.Extension] = None, change_set: models.ChangeSet = None
+        self,
+        job_result: JobResult = None,
+        extensions: List[ext.Extension] = None,
+        change_set: models.ChangeSet = None,
+        import_mode=False,
     ):
         """Create a new build environment for implementing designs.
 
@@ -698,7 +703,7 @@ class Environment(LoggingMixin):
         """
         self.job_result = job_result
         self.logger = get_logger(__name__, self.job_result)
-
+        self.import_mode = import_mode
         self.extensions = {
             "extensions": [],
             "attribute": {},
@@ -722,7 +727,7 @@ class Environment(LoggingMixin):
 
             self.extensions["extensions"].append(extn)
 
-        self.journal = Journal(change_set=change_set)
+        self.journal = Journal(change_set=change_set, import_mode=import_mode)
         if change_set:
             self.deployment = change_set.deployment
 
@@ -772,7 +777,7 @@ class Environment(LoggingMixin):
         try:
             for key, value in design.items():
                 if key in self.model_map and value:
-                    self._create_objects(self.model_map[key], value)
+                    self._create_or_import_objects(self.model_map[key], value)
                 elif key not in self.model_map:
                     raise errors.DesignImplementationError(f"Unknown model key {key} in design")
 
@@ -842,7 +847,7 @@ class Environment(LoggingMixin):
                 value[k] = self.resolve_value(item)
         return value
 
-    def _create_objects(self, model_class: Type[ModelInstance], objects: Union[List[Any], Dict[str, Any]]):
+    def _create_or_import_objects(self, model_class: Type[ModelInstance], objects: Union[List[Any], Dict[str, Any]]):
         if isinstance(objects, dict):
             model = model_class(self, objects)
             model.save()

--- a/nautobot_design_builder/fields.py
+++ b/nautobot_design_builder/fields.py
@@ -80,7 +80,8 @@ def change_log(model_instance: "ModelInstance", attr_name: str):
     old_value = _get_change_value(getattr(model_instance.instance, attr_name))
     yield
     new_value = _get_change_value(getattr(model_instance.instance, attr_name))
-    if old_value != new_value:
+    if old_value != new_value or model_instance.environment.import_mode:
+
         if isinstance(old_value, set):
             model_instance.metadata.changes[attr_name] = {
                 "old_items": old_value,

--- a/nautobot_design_builder/jobs.py
+++ b/nautobot_design_builder/jobs.py
@@ -1,6 +1,6 @@
 """Generic Design Builder Jobs."""
 
-from nautobot.extras.jobs import Job, MultiObjectVar
+from nautobot.extras.jobs import Job, MultiObjectVar, BooleanVar
 
 from .logging import get_logger
 from .models import Deployment
@@ -17,6 +17,10 @@ class DeploymentDecommissioning(Job):
         query_params={"status": "active"},
         description="Design Deployments to decommission.",
     )
+    only_traceability = BooleanVar(
+        description="Only remove the objects traceability, not decommissioning the actual data.",
+        default=False,
+    )
 
     class Meta:  # pylint: disable=too-few-public-methods
         """Meta class."""
@@ -27,14 +31,29 @@ class DeploymentDecommissioning(Job):
     def run(self, data, commit):
         """Execute Decommissioning job."""
         deployments = data["deployments"]
+        only_traceability = data["only_traceability"]
+
         self.log_info(
             message=f"Starting decommissioning of design deployments: {', '.join([instance.name for instance in deployments])}",
         )
 
         for deployment in deployments:
-            self.log_info(obj=deployment, message="Working on resetting objects for this Design Deployment...")
-            deployment.decommission(local_logger=get_logger(__name__, self.job_result))
-            self.log_success(f"{deployment} has been successfully decommissioned from Nautobot.")
+            if only_traceability:
+                message = "Working on resetting traceability for this Design Deployment..."
+            else:
+                message = "Working on resetting objects for this Design Deployment..."
+            self.log_info(obj=deployment, message=message)
+
+            deployment.decommission(
+                local_logger=get_logger(__name__, self.job_result), only_traceability=only_traceability
+            )
+
+            if only_traceability:
+                message = f"Traceability for {deployment} has been successfully removed from Nautobot."
+            else:
+                message = f"{deployment} has been successfully decommissioned from Nautobot."
+
+            self.log_success(message)
 
 
 jobs = (DeploymentDecommissioning,)

--- a/nautobot_design_builder/tests/designs/templates/simple_design_1.yaml.j2
+++ b/nautobot_design_builder/tests/designs/templates/simple_design_1.yaml.j2
@@ -1,0 +1,3 @@
+---
+manufacturers:
+    - "!create_or_update:name": "Test Manufacturer"

--- a/nautobot_design_builder/tests/designs/templates/simple_design_4.yaml.j2
+++ b/nautobot_design_builder/tests/designs/templates/simple_design_4.yaml.j2
@@ -1,0 +1,3 @@
+---
+manufacturers:
+    "name": "Test Manufacturer"

--- a/nautobot_design_builder/tests/designs/templates/simple_design_5.yaml.j2
+++ b/nautobot_design_builder/tests/designs/templates/simple_design_5.yaml.j2
@@ -1,4 +1,4 @@
 ---
 manufacturers:
-    - "!create_or_update:name": "Test Manufacturer"
+    - "!update:name": "Test Manufacturer"
       "description": "Test description"

--- a/nautobot_design_builder/tests/designs/test_designs.py
+++ b/nautobot_design_builder/tests/designs/test_designs.py
@@ -107,8 +107,26 @@ class SimpleDesignDeploymentMode(DesignJob):
     """Simple design job in deployment mode."""
 
     class Meta:  # pylint: disable=too-few-public-methods
-        name = "Simple Design in deployment mode"
+        name = "Simple Design in deployment mode with create_or_update"
         design_file = "templates/simple_design_1.yaml.j2"
+        design_mode = DesignModeChoices.DEPLOYMENT
+
+
+class SimpleDesignDeploymentModeCreate(DesignJob):
+    """Simple design job in deployment mode for 'create'."""
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        name = "Simple Design in deployment mode with create"
+        design_file = "templates/simple_design_4.yaml.j2"
+        design_mode = DesignModeChoices.DEPLOYMENT
+
+
+class SimpleDesignDeploymentModeUpdate(DesignJob):
+    """Simple design job in deployment mode for 'update'."""
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        name = "Simple Design in deployment mode with update"
+        design_file = "templates/simple_design_5.yaml.j2"
         design_mode = DesignModeChoices.DEPLOYMENT
 
 

--- a/nautobot_design_builder/tests/designs/test_designs.py
+++ b/nautobot_design_builder/tests/designs/test_designs.py
@@ -103,6 +103,15 @@ class DesignWithValidationError(DesignJob):
         design_file = "templates/design_with_validation_error.yaml.j2"
 
 
+class SimpleDesignDeploymentMode(DesignJob):
+    """Simple design job in deployment mode."""
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        name = "Simple Design in deployment mode"
+        design_file = "templates/simple_design_1.yaml.j2"
+        design_mode = DesignModeChoices.DEPLOYMENT
+
+
 class NextInterfaceExtension(AttributeExtension):
     """Attribute extension to calculate the next available interface name."""
 

--- a/nautobot_design_builder/tests/test_decommissioning_job.py
+++ b/nautobot_design_builder/tests/test_decommissioning_job.py
@@ -131,7 +131,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         )
         record.validated_save()
 
-        self.job.run(data={"deployments": [self.deployment]}, commit=True)
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": False}, commit=True)
 
         self.assertEqual(0, Secret.objects.count())
 
@@ -159,7 +159,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         self.assertRaises(
             ValueError,
             self.job.run,
-            {"deployments": [self.deployment]},
+            {"deployments": [self.deployment], "only_traceability": False},
             True,
         )
 
@@ -188,7 +188,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
 
         self.deployment_2.decommission()
 
-        self.job.run(data={"deployments": [self.deployment]}, commit=True)
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": False}, commit=True)
 
         self.assertEqual(0, Secret.objects.count())
 
@@ -204,7 +204,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         )
         record_1.validated_save()
 
-        self.job.run(data={"deployments": [self.deployment]}, commit=True)
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": False}, commit=True)
 
         self.assertEqual(1, Secret.objects.count())
 
@@ -223,7 +223,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         )
         record.validated_save()
 
-        self.job.run(data={"deployments": [self.deployment]}, commit=True)
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": False}, commit=True)
 
         self.assertEqual(1, Secret.objects.count())
         self.assertEqual("previous description", Secret.objects.first().description)
@@ -240,7 +240,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         )
         record.validated_save()
 
-        self.job.run(data={"deployments": [self.deployment]}, commit=True)
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": False}, commit=True)
 
         self.assertEqual(self.initial_params, Secret.objects.first().parameters)
 
@@ -259,7 +259,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         )
         record.validated_save()
 
-        self.job.run(data={"deployments": [self.deployment]}, commit=True)
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": False}, commit=True)
 
         self.assertEqual(self.initial_params, Secret.objects.first().parameters)
 
@@ -283,7 +283,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         self.secret.parameters = {**self.changed_params, **new_params}
         self.secret.validated_save()
 
-        self.job.run(data={"deployments": [self.deployment]}, commit=True)
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": False}, commit=True)
 
         self.assertEqual({**self.initial_params, **new_params}, Secret.objects.first().parameters)
 
@@ -299,7 +299,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         )
         record_1.validated_save()
 
-        self.job.run(data={"deployments": [self.deployment]}, commit=True)
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": False}, commit=True)
 
         self.assertEqual(0, Secret.objects.count())
         models.Deployment.pre_decommission.disconnect(fake_ok)
@@ -318,7 +318,7 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
         self.assertRaises(
             DesignValidationError,
             self.job.run,
-            {"deployments": [self.deployment]},
+            {"deployments": [self.deployment], "only_traceability": False},
             True,
         )
 
@@ -351,6 +351,25 @@ class DecommissionJobTestCase(DesignTestCase):  # pylint: disable=too-many-insta
 
         self.assertEqual(2, Secret.objects.count())
 
-        self.job.run(data={"deployments": [self.deployment, self.deployment_2]}, commit=True)
+        self.job.run(
+            data={"deployments": [self.deployment, self.deployment_2], "only_traceability": False}, commit=True
+        )
 
         self.assertEqual(0, Secret.objects.count())
+
+    def test_decommission_run_with_only_traceability(self):
+        self.assertEqual(1, Secret.objects.count())
+
+        record = models.ChangeRecord.objects.create(
+            change_set=self.change_set1,
+            design_object=self.secret,
+            full_control=True,
+            index=self.change_set1._next_index(),  # pylint:disable=protected-access
+        )
+        record.validated_save()
+
+        self.job.run(data={"deployments": [self.deployment], "only_traceability": True}, commit=True)
+
+        self.assertEqual(1, Secret.objects.count())
+        record.refresh_from_db()
+        self.assertEqual(False, record.active)


### PR DESCRIPTION
This PR adds a new feature to import existing data into a new Design Deployment

TODOs:

- [x] Check why identifiers are not included in the imported change record
- [x] Include more actions other than "create_and_update", cover the "create" and "update" (for attributes only, not full control)
- [x] Create a queryset used many times
- [x] Add Docs for the new functionality
- [x] Add a functionality to remove traceability when decommissioning a design deployment 