### PR TITLE
fix: Fixes most likely issues with attribute collisions

### DIFF
--- a/examples/custom_design/designs/p2p/jobs.py
+++ b/examples/custom_design/designs/p2p/jobs.py
@@ -38,7 +38,7 @@ class NextInterfaceExtension(AttributeExtension):
             tags__name="VRF Interface",
         ).first()
         if existing_interface:
-            model_instance.instance = existing_interface
+            model_instance.design_instance = existing_interface
             return {"!create_or_update:name": existing_interface.name}
         return {"!create_or_update:name": f"{root_interface_name}1/{len(interfaces) + 1}"}
 

--- a/nautobot_design_builder/debug.py
+++ b/nautobot_design_builder/debug.py
@@ -8,9 +8,9 @@ DEBUG = False
 
 class ObjDetails:  # noqa:D101  # pylint:disable=too-few-public-methods,missing-class-docstring
     def __init__(self, obj):  # noqa:D107  # pylint:disable=missing-function-docstring
-        self.instance = obj
-        if hasattr(obj, "instance"):
-            self.instance = obj.instance
+        self.design_instance = obj
+        if hasattr(obj, "design_instance"):
+            self.design_instance = obj.design_instance
         try:
             description = str(obj)
             if description.startswith("<class"):
@@ -20,15 +20,15 @@ class ObjDetails:  # noqa:D101  # pylint:disable=too-few-public-methods,missing-
 
         self.obj = obj
         self.obj_class = obj.__class__.__name__
-        self.obj_id = str(getattr(self.instance, "id", None))
-        if hasattr(self.instance, "name"):
-            self.name = getattr(self.instance, "name")
+        self.obj_id = str(getattr(self.design_instance, "id", None))
+        if hasattr(self.design_instance, "name"):
+            self.name = getattr(self.design_instance, "name")
         else:
             self.name = None
         self.description = description
 
     def __str__(self):  # noqa:D105  # pylint:disable=missing-function-docstring
-        if isinstance(self.instance, models.Model):
+        if isinstance(self.design_instance, models.Model):
             string = self.obj_class + " "
             if self.name is not None:
                 string += '"' + self.name + '"' + ":"
@@ -36,7 +36,7 @@ class ObjDetails:  # noqa:D101  # pylint:disable=too-few-public-methods,missing-
                 string += self.description + ":"
             string += self.obj_id
             return string
-        if isinstance(self.instance, dict):
+        if isinstance(self.design_instance, dict):
             return str(self.obj)
         return self.description or self.name or self.obj_class
 

--- a/nautobot_design_builder/design.py
+++ b/nautobot_design_builder/design.py
@@ -57,7 +57,7 @@ class Journal:
         Args:
             model (BaseModel): The model that has been created or updated
         """
-        instance = model.instance
+        instance = model.design_instance
         model_type = instance.__class__
         if self.change_set:
             self.change_set.log(model, self.import_mode)
@@ -65,7 +65,7 @@ class Journal:
         if instance.pk not in self.index:
             self.index.add(instance.pk)
 
-            if model.metadata.created:
+            if model.design_metadata.created:
                 index = self.created
             else:
                 index = self.updated
@@ -97,7 +97,7 @@ def _map_query_values(query: Mapping) -> Mapping:
     retval = {}
     for key, value in query.items():
         if isinstance(value, ModelInstance):
-            retval[key] = value.instance
+            retval[key] = value.design_instance
         elif isinstance(value, Mapping):
             retval[key] = _map_query_values(value)
         else:
@@ -132,7 +132,7 @@ class ModelMetadata:  # pylint: disable=too-many-instance-attributes
     # Actions that work with import mode
     IMPORTABLE_ACTION_CHOICES = [UPDATE, CREATE_OR_UPDATE]
 
-    def __init__(self, model_instance: "ModelInstance", **kwargs):
+    def __init__(self, model_instance: "ModelInstance", environment: "Environment", **kwargs):
         """Initialize the metadata object for a given model instance.
 
         By default, the metadata object doesn't really have anything in it. In order
@@ -141,9 +141,11 @@ class ModelMetadata:  # pylint: disable=too-many-instance-attributes
 
         Args:
             model_instance (ModelInstance): The model instance to which this metadata refers.
+            environment (Environment): The implementation environment being used for the current
+                design.
         """
         self.model_instance = model_instance
-        self.environment = model_instance.environment
+        self.environment = environment
 
         self.created = False
 
@@ -166,6 +168,11 @@ class ModelMetadata:  # pylint: disable=too-many-instance-attributes
         self._deferred = False
         self._filter = {}
         self._kwargs = {}
+
+    @property
+    def import_mode(self) -> bool:
+        """Indicates whether the underlying environment is in import mode or not."""
+        return self.environment.import_mode
 
     @property
     def action(self) -> str:
@@ -270,7 +277,7 @@ class ModelMetadata:  # pylint: disable=too-many-instance-attributes
             elif not hasattr(self.model_instance, key):
                 value = self._attributes.pop(key)
                 if isinstance(value, ModelInstance):
-                    value = value.instance
+                    value = value.design_instance
                 self._kwargs[key] = value
 
     def connect(self, signal: str, handler: FunctionType):
@@ -290,7 +297,113 @@ class ModelMetadata:  # pylint: disable=too-many-instance-attributes
         """
         for handler in self._signals[signal]:
             handler()
-            self.model_instance.instance.refresh_from_db()
+            self.model_instance.design_instance.refresh_from_db()
+
+    def create_child(
+        self,
+        model_class: "ModelInstance",
+        attributes: Dict,
+        relationship_manager: Manager = None,
+    ) -> "ModelInstance":
+        """Create a new ModelInstance that is linked to the current instance.
+
+        Args:
+            model_class (Type[Model]): Class of the child model.
+            attributes (Dict): Design attributes for the child.
+            relationship_manager (Manager): Database relationship manager to use for the new instance.
+
+        Returns:
+            ModelInstance: Model instance that has its parent correctly set.
+        """
+        if not issubclass(model_class, ModelInstance):
+            model_class = self.environment.model_class_index[model_class]
+        try:
+            model_instance = model_class(
+                self.environment,
+                attributes,
+                relationship_manager,
+                parent=self,
+            )
+            # Add the newly created instance to the log so we can keep track of
+            # it belonging to a design.
+            self.environment.journal.log(model_instance)
+            return model_instance
+        except MultipleObjectsReturned:
+            # pylint: disable=raise-missing-from
+            raise errors.DesignImplementationError(
+                f"Expected exactly 1 object for {model_class.__name__}({attributes}) but got more than one"
+            )
+        except ObjectDoesNotExist:
+            query = ",".join([f'{k}="{v}"' for k, v in attributes.items()])
+            # pylint: disable=raise-missing-from
+            raise errors.DesignImplementationError(f"Could not find {model_class.__name__}: {query}")
+
+    def load_instance(self):  # pylint: disable=too-many-branches
+        """Load the model instance's design instance from the database.
+
+        This method will either create a new object or load an existing object
+        from the database, based on the action tags and query strings specified
+        in the design.
+        """
+        # Short circuit if the instance was loaded earlier in
+        # the initialization process
+        if self.model_instance.design_instance is not None:
+            return
+
+        query_filter = self.query_filter
+        field_values = self.query_filter_values
+        if self.action == ModelMetadata.GET:
+            self.model_instance.design_instance = self.model_instance.model_class.objects.get(**query_filter)
+            return
+
+        if self.action in [ModelMetadata.UPDATE, ModelMetadata.CREATE_OR_UPDATE]:
+            # perform nested lookups. First collect all the
+            # query params for top-level relationships, then
+            # perform the actual lookup
+            for query_param in list(query_filter.keys()):
+                if "__" in query_param:
+                    value = query_filter.pop(query_param)
+                    attribute, filter_param = query_param.split("__", 1)
+                    query_filter.setdefault(attribute, {})
+                    query_filter[attribute][f"!get:{filter_param}"] = value
+
+            for query_param, value in query_filter.items():
+                if isinstance(value, Mapping):
+                    rel: Manager = getattr(self.model_instance.model_class, query_param)
+                    queryset: QuerySet = rel.get_queryset()
+
+                    model = self.create_child(
+                        self.environment.model_class_index[queryset.model],
+                        value,
+                        relationship_manager=queryset,
+                    )
+                    if model.design_metadata.action != ModelMetadata.GET:
+                        model.save()
+                    query_filter[query_param] = model.design_instance
+                    field_values[query_param] = model
+            try:
+                self.model_instance.design_instance = self.model_instance.relationship_manager.get(**query_filter)
+                return
+            except ObjectDoesNotExist:
+                if self.action == ModelMetadata.UPDATE:
+                    # pylint: disable=raise-missing-from
+                    raise errors.DesignImplementationError(
+                        f"No match with {query_filter}", self.model_instance.model_class
+                    )
+                self.created = True
+                # since the object was not found, we need to
+                # put the search criteria back into the attributes
+                # so that they will be set when the object is created
+                self.attributes.update(field_values)
+        elif self.action != ModelMetadata.CREATE:
+            raise errors.DesignImplementationError(
+                f"Unknown database action {self.action}", self.model_instance.model_class
+            )
+        try:
+            self.model_instance.design_instance = self.model_instance.model_class(**self.kwargs)
+            self.created = True
+        except TypeError as ex:
+            raise errors.DesignImplementationError(str(ex), self.model_instance.model_class)
 
     @property
     def custom_fields(self) -> Dict[str, Any]:
@@ -378,6 +491,26 @@ class ModelMetadata:  # pylint: disable=too-many-instance-attributes
         return _map_query_values(self._filter)
 
 
+def _refresh_custom_relationships(instance: "ModelInstance"):
+    """Look for any custom relationships for this model class and add any new fields."""
+    for direction in Relationship.objects.get_for_model(instance.model_class):
+        for relationship in direction:
+            field = field_factory(instance, relationship)
+
+            # make sure not to mask non-custom relationship fields that
+            # may have the same key name or field name
+            for attr_name in [field.key_name, field.field_name]:
+                if hasattr(instance.__class__, attr_name):
+                    # if there is already an attribute with the same name,
+                    # delete it if it is a custom relationship, that way
+                    # we reload the config from the database.
+                    if isinstance(getattr(instance.__class__, attr_name), CustomRelationshipField):
+                        delattr(instance.__class__, attr_name)
+
+                if not hasattr(instance.__class__, attr_name):
+                    setattr(instance.__class__, attr_name, field)
+
+
 class ModelInstance:
     """An individual object to be created or updated as Design Builder iterates through a rendered design YAML file.
 
@@ -437,82 +570,28 @@ class ModelInstance:
             errors.MultipleObjectsReturnedError: If the object is being retrieved or updated (not created)
                 and more than one object matches the lookup criteria.
         """
-        self.environment = environment
-        self.instance: Model = None
-        self.metadata = ModelMetadata(self, **attributes.pop("model_metadata", {}))
-        self._parent = parent
-        self.refresh_custom_relationships()
+        self.design_instance: Model = None
+        self.design_metadata = ModelMetadata(self, environment, **attributes.pop("model_metadata", {}))
+        self._design_instance_parent = parent
+        _refresh_custom_relationships(self)
         self.relationship_manager = relationship_manager
         if self.relationship_manager is None:
             self.relationship_manager = self.model_class.objects
 
-        self.metadata.attributes = attributes
+        self.design_metadata.attributes = attributes
 
         try:
-            self._load_instance()
-            setattr(self.instance, "__design_builder_instance", self)
+            self.design_metadata.load_instance()
+            setattr(self.design_instance, "__design_builder_instance", self)
         except ObjectDoesNotExist as ex:
             raise errors.DoesNotExistError(self) from ex
         except MultipleObjectsReturned as ex:
             raise errors.MultipleObjectsReturnedError(self) from ex
         self._update_fields()
 
-    def refresh_custom_relationships(self):
-        """Look for any custom relationships for this model class and add any new fields."""
-        for direction in Relationship.objects.get_for_model(self.model_class):
-            for relationship in direction:
-                field = field_factory(self, relationship)
-
-                # make sure not to mask non-custom relationship fields that
-                # may have the same key name or field name
-                for attr_name in [field.key_name, field.field_name]:
-                    if hasattr(self.__class__, attr_name):
-                        # if there is already an attribute with the same name,
-                        # delete it if it is a custom relationship, that way
-                        # we reload the config from the database.
-                        if isinstance(getattr(self.__class__, attr_name), CustomRelationshipField):
-                            delattr(self.__class__, attr_name)
-                    if not hasattr(self.__class__, attr_name):
-                        setattr(self.__class__, attr_name, field)
-
     def __str__(self):
         """Get the model class name."""
         return str(self.model_class)
-
-    def create_child(
-        self,
-        model_class: "ModelInstance",
-        attributes: Dict,
-        relationship_manager: Manager = None,
-    ) -> "ModelInstance":
-        """Create a new ModelInstance that is linked to the current instance.
-
-        Args:
-            model_class (Type[Model]): Class of the child model.
-            attributes (Dict): Design attributes for the child.
-            relationship_manager (Manager): Database relationship manager to use for the new instance.
-
-        Returns:
-            ModelInstance: Model instance that has its parent correctly set.
-        """
-        if not issubclass(model_class, ModelInstance):
-            model_class = self.environment.model_class_index[model_class]
-        try:
-            return model_class(
-                self.environment,
-                attributes,
-                relationship_manager,
-                parent=self,
-            )
-        except MultipleObjectsReturned:
-            # pylint: disable=raise-missing-from
-            raise errors.DesignImplementationError(
-                f"Expected exactly 1 object for {model_class.__name__}({attributes}) but got more than one"
-            )
-        except ObjectDoesNotExist:
-            query = ",".join([f'{k}="{v}"' for k, v in attributes.items()])
-            # pylint: disable=raise-missing-from
-            raise errors.DesignImplementationError(f"Could not find {model_class.__name__}: {query}")
 
     def connect(self, signal: str, handler: FunctionType):
         """Connect a handler between this model instance (as sender) and signal.
@@ -521,86 +600,28 @@ class ModelInstance:
             signal (Signal): Signal to listen for.
             handler (FunctionType): Callback function
         """
-        self.metadata.connect(signal, handler)
+        self.design_metadata.connect(signal, handler)
 
     def _send(self, signal: str):
-        self.metadata.send(signal)
-
-    def _load_instance(self):  # pylint: disable=too-many-branches
-        # Short circuit if the instance was loaded earlier in
-        # the initialization process
-        if self.instance is not None:
-            return
-
-        query_filter = self.metadata.query_filter
-        field_values = self.metadata.query_filter_values
-        if self.metadata.action == ModelMetadata.GET:
-            self.instance = self.model_class.objects.get(**query_filter)
-            return
-
-        if self.metadata.action in [ModelMetadata.UPDATE, ModelMetadata.CREATE_OR_UPDATE]:
-            # perform nested lookups. First collect all the
-            # query params for top-level relationships, then
-            # perform the actual lookup
-            for query_param in list(query_filter.keys()):
-                if "__" in query_param:
-                    value = query_filter.pop(query_param)
-                    attribute, filter_param = query_param.split("__", 1)
-                    query_filter.setdefault(attribute, {})
-                    query_filter[attribute][f"!get:{filter_param}"] = value
-
-            for query_param, value in query_filter.items():
-                if isinstance(value, Mapping):
-                    rel: Manager = getattr(self.model_class, query_param)
-                    queryset: QuerySet = rel.get_queryset()
-
-                    model = self.create_child(
-                        self.environment.model_class_index[queryset.model],
-                        value,
-                        relationship_manager=queryset,
-                    )
-                    if model.metadata.action != ModelMetadata.GET:
-                        model.save()
-                    query_filter[query_param] = model.instance
-                    field_values[query_param] = model
-            try:
-                self.instance = self.relationship_manager.get(**query_filter)
-                return
-            except ObjectDoesNotExist:
-                if self.metadata.action == ModelMetadata.UPDATE:
-                    # pylint: disable=raise-missing-from
-                    raise errors.DesignImplementationError(f"No match with {query_filter}", self.model_class)
-                self.metadata.created = True
-                # since the object was not found, we need to
-                # put the search criteria back into the attributes
-                # so that they will be set when the object is created
-                self.metadata.attributes.update(field_values)
-        elif self.metadata.action != ModelMetadata.CREATE:
-            raise errors.DesignImplementationError(f"Unknown database action {self.metadata.action}", self.model_class)
-        try:
-            self._initial_state = {}
-            self.instance = self.model_class(**self.metadata.kwargs)
-            self.metadata.created = True
-        except TypeError as ex:
-            raise errors.DesignImplementationError(str(ex), self.model_class)
+        self.design_metadata.send(signal)
 
     def _update_fields(self):
-        if self.metadata.action == ModelMetadata.GET:
-            if self.metadata.attributes:
+        if self.design_metadata.action == ModelMetadata.GET:
+            if self.design_metadata.attributes:
                 # TODO: Raise a DesignModelError from here. Currently the DesignModelError doesn't
                 # include a message.
                 raise errors.DesignImplementationError(
                     "Cannot update fields when using the GET action", self.model_class
                 )
 
-        for field_name, value in self.metadata.attributes.items():
+        for field_name, value in self.design_metadata.attributes.items():
             if hasattr(self.__class__, field_name):
                 setattr(self, field_name, value)
-            elif hasattr(self.instance, field_name):
-                setattr(self.instance, field_name, value)
+            elif hasattr(self.design_instance, field_name):
+                setattr(self.design_instance, field_name, value)
 
-        for key, value in self.metadata.custom_fields.items():
-            self.set_custom_field(key, value)
+        for key, value in self.design_metadata.custom_fields.items():
+            self.design_instance.cf[key] = value
 
     def save(self):
         """Save the model instance to the database.
@@ -609,33 +630,29 @@ class ModelInstance:
         will send signals (`PRE_SAVE`, `POST_INSTANCE_SAVE` and `POST_SAVE`). The
         design journal is updated in this step.
         """
-        if self.metadata.action == ModelMetadata.GET:
+        if self.design_metadata.action == ModelMetadata.GET:
             return
 
         self._send(ModelMetadata.PRE_SAVE)
 
-        msg = "Created" if self.metadata.created else "Updated"
+        msg = "Created" if self.design_metadata.created else "Updated"
         try:
-            self.instance.full_clean()
-            self.instance.save(**self.metadata.save_args)
-            self.environment.journal.log(self)
-            self.metadata.created = False
-            if self._parent is None:
-                self.environment.log_success(
-                    message=f"{msg} {self.model_class.__name__} {self.instance}", obj=self.instance
+            self.design_instance.full_clean()
+            self.design_instance.save(**self.design_metadata.save_args)
+            self.design_metadata.environment.journal.log(self)
+            self.design_metadata.created = False
+            if self._design_instance_parent is None:
+                self.design_metadata.environment.log_success(
+                    message=f"{msg} {self.model_class.__name__} {self.design_instance}", obj=self.design_instance
                 )
             # Refresh from DB so that we update based on any
             # post save signals that may have fired.
-            self.instance.refresh_from_db()
+            self.design_instance.refresh_from_db()
         except ValidationError as validation_error:
             raise errors.DesignValidationError(self) from validation_error
 
         self._send(ModelMetadata.POST_INSTANCE_SAVE)
         self._send(ModelMetadata.POST_SAVE)
-
-    def set_custom_field(self, field, value):
-        """Sets a value for a custom field."""
-        self.instance.cf[field] = value
 
 
 # Don't add models from these app_labels to the

--- a/nautobot_design_builder/errors.py
+++ b/nautobot_design_builder/errors.py
@@ -52,7 +52,7 @@ class DesignModelError(Exception):
     @staticmethod
     def _model_str(model):
         instance_str = None
-        if not isinstance(model, Model) and not hasattr(model, "instance"):
+        if not isinstance(model, Model) and not hasattr(model, "design_instance"):
             if isclass(model):
                 return model.__name__
             try:
@@ -67,9 +67,9 @@ class DesignModelError(Exception):
 
         model_class = model.__class__
         # if it looks like a duck...
-        if hasattr(model, "instance"):
+        if hasattr(model, "design_instance"):
             model_class = model.model_class
-            model = model.instance
+            model = model.design_instance
 
         if model:
             try:
@@ -112,8 +112,8 @@ class DesignModelError(Exception):
         model = self.model
         while model is not None:
             path_msg.insert(0, DesignModelError._model_str(model))
-            if not isclass(model) and hasattr(model, "_parent"):
-                model = model._parent  # pylint:disable=protected-access
+            if not isclass(model) and hasattr(model, "_design_instance_parent"):
+                model = model._design_instance_parent  # pylint:disable=protected-access
             elif self.parent:
                 model = self.parent
                 self.parent = None

--- a/nautobot_design_builder/ext.py
+++ b/nautobot_design_builder/ext.py
@@ -203,12 +203,13 @@ class ReferenceExtension(AttributeExtension, ValueExtension):
         except KeyError:
             # pylint: disable=raise-missing-from
             raise DesignImplementationError(f"No ref named {key} has been saved in the design.")
-        if model_instance.instance and not model_instance.instance._state.adding:  # pylint: disable=protected-access
-            model_instance.instance.refresh_from_db()
+        adding = model_instance.design_instance._state.adding  # pylint: disable=protected-access
+        if model_instance.design_instance and not adding:
+            model_instance.design_instance.refresh_from_db()
         if attribute:
             # TODO: I think the result of the reduce operation needs to (potentially)
             # be wrapped up in a ModelInstance object
-            return reduce(getattr, [model_instance.instance, *attribute.split(".")])
+            return reduce(getattr, [model_instance.design_instance, *attribute.split(".")])
         return model_instance
 
 

--- a/nautobot_design_builder/fields.py
+++ b/nautobot_design_builder/fields.py
@@ -77,18 +77,18 @@ def change_log(model_instance: "ModelInstance", attr_name: str):
         model_instance (ModelInstance): The model instance that is being updated.
         attr_name (str): The attribute to be updated.
     """
-    old_value = _get_change_value(getattr(model_instance.instance, attr_name))
+    old_value = _get_change_value(getattr(model_instance.design_instance, attr_name))
     yield
-    new_value = _get_change_value(getattr(model_instance.instance, attr_name))
-    if old_value != new_value or model_instance.environment.import_mode:
+    new_value = _get_change_value(getattr(model_instance.design_instance, attr_name))
+    if old_value != new_value or model_instance.design_metadata.import_mode:
 
         if isinstance(old_value, set):
-            model_instance.metadata.changes[attr_name] = {
+            model_instance.design_metadata.changes[attr_name] = {
                 "old_items": old_value,
                 "new_items": new_value,
             }
         else:
-            model_instance.metadata.changes[attr_name] = {
+            model_instance.design_metadata.changes[attr_name] = {
                 "old_value": old_value,
                 "new_value": new_value,
             }
@@ -121,9 +121,9 @@ class ModelField(ABC):
         Returns:
             Any: Either the descriptor instance or the field value.
         """
-        if obj is None or obj.instance is None:
+        if obj is None or obj.design_instance is None:
             return self
-        return getattr(obj.instance, self.field_name)
+        return getattr(obj.design_instance, self.field_name)
 
     @abstractmethod
     def __set__(self, obj: "ModelInstance", value):
@@ -171,7 +171,7 @@ class SimpleField(BaseModelField):  # pylint:disable=too-few-public-methods
     @debug_set
     def __set__(self, obj: "ModelInstance", value):  # noqa: D105
         with change_log(obj, self.field_name):
-            setattr(obj.instance, self.field_name, value)
+            setattr(obj.design_instance, self.field_name, value)
 
 
 class RelationshipFieldMixin:  # pylint:disable=too-few-public-methods
@@ -203,7 +203,7 @@ class RelationshipFieldMixin:  # pylint:disable=too-few-public-methods
             ModelInstance: Either a newly created `ModelInstance` or the original value.
         """
         if isinstance(value, Mapping):
-            value = obj.create_child(self.related_model, value, relationship_manager)
+            value = obj.design_metadata.create_child(self.related_model, value, relationship_manager)
         return value
 
 
@@ -216,16 +216,14 @@ class ForeignKeyField(BaseModelField, RelationshipFieldMixin):  # pylint:disable
 
         def setter():
             model_instance = self._get_instance(obj, value)
-            if model_instance.metadata.created:
+            if model_instance.design_metadata.created:
                 model_instance.save()
-            else:
-                model_instance.environment.journal.log(model_instance)
 
             with change_log(obj, self.field.attname):
-                setattr(obj.instance, self.field_name, model_instance.instance)
+                setattr(obj.design_instance, self.field_name, model_instance.design_instance)
 
             if deferred:
-                obj.instance.save(update_fields=[self.field_name])
+                obj.design_instance.save(update_fields=[self.field_name])
 
         if deferred:
             obj.connect("POST_INSTANCE_SAVE", setter)
@@ -245,7 +243,7 @@ class ManyToOneRelField(BaseModelField, RelationshipFieldMixin):  # pylint:disab
             for value in values:
                 value = self._get_instance(obj, value, getattr(obj, self.field_name))
                 with change_log(value, self.field.field.attname):
-                    setattr(value.instance, self.field.field.name, obj.instance)
+                    setattr(value.design_instance, self.field.field.name, obj.design_instance)
                 value.save()
 
         obj.connect("POST_INSTANCE_SAVE", setter)
@@ -266,14 +264,12 @@ class ManyToManyField(BaseModelField, RelationshipFieldMixin):  # pylint:disable
         def setter():
             items = []
             for value in values:
-                value = self._get_instance(obj, value, getattr(obj.instance, self.field_name))
-                if value.metadata.created:
+                value = self._get_instance(obj, value, getattr(obj.design_instance, self.field_name))
+                if value.design_metadata.created:
                     value.save()
-                else:
-                    value.environment.journal.log(value)
-                items.append(value.instance)
+                items.append(value.design_instance)
             with change_log(obj, self.field_name):
-                getattr(obj.instance, self.field_name).add(*items)
+                getattr(obj.design_instance, self.field_name).add(*items)
 
         obj.connect("POST_INSTANCE_SAVE", setter)
 
@@ -288,13 +284,11 @@ class GenericRelationField(BaseModelField, RelationshipFieldMixin):  # pylint:di
         items = []
         for value in values:
             value = self._get_instance(obj, value)
-            if value.metadata.created:
+            if value.design_metadata.created:
                 value.save()
-            else:
-                value.environment.journal.log(value)
-            items.append(value.instance)
+            items.append(value.design_instance)
         with change_log(obj, self.field_name):
-            getattr(obj.instance, self.field_name).add(*items)
+            getattr(obj.design_instance, self.field_name).add(*items)
 
 
 class GenericForeignKeyField(BaseModelField, RelationshipFieldMixin):  # pylint:disable=too-few-public-methods
@@ -304,10 +298,10 @@ class GenericForeignKeyField(BaseModelField, RelationshipFieldMixin):  # pylint:
     def __set__(self, obj: "ModelInstance", value):  # noqa:D105
         fk_field = self.field.fk_field
         ct_field = self.field.ct_field
-        ct_id_field = obj.instance._meta.get_field(ct_field).attname
+        ct_id_field = obj.design_instance._meta.get_field(ct_field).attname
         with change_log(obj, fk_field), change_log(obj, ct_id_field):
-            setattr(obj.instance, fk_field, value.instance.pk)
-            setattr(obj.instance, ct_field, ContentType.objects.get_for_model(value.instance))
+            setattr(obj.design_instance, fk_field, value.design_instance.pk)
+            setattr(obj.design_instance, ct_field, ContentType.objects.get_for_model(value.design_instance))
 
 
 class TagField(ManyToManyField):  # pylint:disable=too-few-public-methods
@@ -324,7 +318,7 @@ class GenericRelField(BaseModelField, RelationshipFieldMixin):  # pylint:disable
     @debug_set
     def __set__(self, obj: "ModelInstance", value):  # noqa:D105
         with change_log(obj, self.field.attname):
-            setattr(obj.instance, self.field.attname, self._get_instance(obj, value))
+            setattr(obj.design_instance, self.field.attname, self._get_instance(obj, value))
 
 
 class CustomRelationshipField(ModelField, RelationshipFieldMixin):  # pylint: disable=too-few-public-methods
@@ -359,20 +353,18 @@ class CustomRelationshipField(ModelField, RelationshipFieldMixin):  # pylint: di
         def setter():
             for value in values:
                 value = self._get_instance(obj, value)
-                if value.metadata.created:
+                if value.design_metadata.created:
                     value.save()
-                else:
-                    value.environment.journal.log(value)
 
-                source = obj.instance
-                destination = value.instance
+                source = obj.design_instance
+                destination = value.design_instance
                 if self.relationship.source_type == ContentType.objects.get_for_model(destination):
                     source, destination = destination, source
 
                 source_type = ContentType.objects.get_for_model(source)
                 destination_type = ContentType.objects.get_for_model(destination)
-                relationship_association = obj.environment.model_class_index[RelationshipAssociation](
-                    environment=obj.environment,
+                relationship_association = obj.design_metadata.create_child(
+                    RelationshipAssociation,
                     attributes={
                         "relationship_id": self.relationship.id,
                         "source_id": source.id,
@@ -380,7 +372,6 @@ class CustomRelationshipField(ModelField, RelationshipFieldMixin):  # pylint: di
                         "destination_id": destination.id,
                         "destination_type_id": destination_type.id,
                     },
-                    parent=obj,
                 )
                 relationship_association.save()
 

--- a/nautobot_design_builder/tests/designs/test_designs.py
+++ b/nautobot_design_builder/tests/designs/test_designs.py
@@ -156,7 +156,7 @@ class NextInterfaceExtension(AttributeExtension):
             tags__name="VRF Interface",
         ).first()
         if existing_interface:
-            model_instance.instance = existing_interface
+            model_instance.design_instance = existing_interface
             return {"!create_or_update:name": existing_interface.name}
         return {"!create_or_update:name": f"{root_interface_name}1/{len(interfaces) + 1}"}
 

--- a/nautobot_design_builder/tests/test_errors.py
+++ b/nautobot_design_builder/tests/test_errors.py
@@ -15,11 +15,11 @@ class TestDesignModelError(unittest.TestCase):
 
         def __init__(self, title="", parent=None):
             self.title = title
-            self.instance = self
+            self.design_instance = self
             self.model_class = self
             self._meta = self
             self.verbose_name = "verbose name"
-            self._parent = parent
+            self._design_instance_parent = parent
 
         def __str__(self):
             return self.title


### PR DESCRIPTION
This fixes an issue where some Nautobot models have an `environment` or `metadata` field name. Almost all instance attributes in `ModelInstance` have been moved into the `ModelMetadata` class, and other fields have been prefixed to reduce the likelyhood of collision.

Fixes #160