### PR TITLE
fix: Fixes most likely issues with attribute collisions

### DIFF
--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -66,7 +66,7 @@ class LookupMixin:
                 yield from LookupMixin._flatten(value, f"{prefix}{key}__")
             else:
                 if isinstance(value, ModelInstance):
-                    yield (f"!get:{prefix}{key}", value.instance)
+                    yield (f"!get:{prefix}{key}", value.design_instance)
                 else:
                     yield (f"!get:{prefix}{key}", value)
 
@@ -121,7 +121,7 @@ class LookupMixin:
         try:
             model_class = self.environment.model_class_index[queryset.model]
             if parent:
-                return parent.create_child(model_class, query, queryset)
+                return parent.design_metadata.create_child(model_class, query, queryset)
             return model_class(self.environment, query, queryset)
         except ObjectDoesNotExist:
             # pylint: disable=raise-missing-from
@@ -289,9 +289,9 @@ class CableConnectionExtension(AttributeExtension, LookupMixin):
             {
                 "termination_a": model_instance,
                 "!create_or_update:termination_b_type_id": ContentType.objects.get_for_model(
-                    remote_instance.instance
+                    remote_instance.design_instance
                 ).id,
-                "!create_or_update:termination_b_id": remote_instance.instance.id,
+                "!create_or_update:termination_b_id": remote_instance.design_instance.id,
                 "deferred": True,
             }
         )
@@ -437,7 +437,7 @@ class ChildPrefixExtension(AttributeExtension):
         if parent is None:
             raise DesignImplementationError("the child_prefix tag requires a parent")
         if isinstance(parent, ModelInstance):
-            parent = str(parent.instance.prefix)
+            parent = str(parent.design_instance.prefix)
         elif not isinstance(parent, str):
             raise DesignImplementationError("parent prefix must be either a previously created object or a string.")
 
@@ -528,8 +528,8 @@ class BGPPeeringExtension(AttributeExtension):
         peering_a = None
         peering_z = None
         try:
-            peering_a = endpoint_a.instance.peering
-            peering_z = endpoint_z.instance.peering
+            peering_a = endpoint_a.design_instance.peering
+            peering_z = endpoint_z.design_instance.peering
         except self.Peering.model_class.DoesNotExist:
             pass
 
@@ -544,13 +544,13 @@ class BGPPeeringExtension(AttributeExtension):
                 peering_z.delete()
 
         retval["endpoints"] = [endpoint_a, endpoint_z]
-        endpoint_a.metadata.attributes["peering"] = model_instance
-        endpoint_z.metadata.attributes["peering"] = model_instance
+        endpoint_a.design_metadata.attributes["peering"] = model_instance
+        endpoint_z.design_metadata.attributes["peering"] = model_instance
 
         def post_save():
             peering_instance: ModelInstance = model_instance
-            endpoint_a = peering_instance.instance.endpoint_a
-            endpoint_z = peering_instance.instance.endpoint_z
+            endpoint_a = peering_instance.design_instance.endpoint_a
+            endpoint_z = peering_instance.design_instance.endpoint_z
             endpoint_a.peer, endpoint_z.peer = endpoint_z, endpoint_a
             endpoint_a.save()
             endpoint_z.save()

--- a/nautobot_design_builder/debug.py
+++ b/nautobot_design_builder/debug.py
@@ -8,9 +8,9 @@ DEBUG = False
 
 class ObjDetails:  # noqa:D101  # pylint:disable=too-few-public-methods,missing-class-docstring
     def __init__(self, obj):  # noqa:D107  # pylint:disable=missing-function-docstring
-        self.instance = obj
-        if hasattr(obj, "instance"):
-            self.instance = obj.instance
+        self.design_instance = obj
+        if hasattr(obj, "design_instance"):
+            self.design_instance = obj.design_instance
         try:
             description = str(obj)
             if description.startswith("<class"):
@@ -20,15 +20,15 @@ class ObjDetails:  # noqa:D101  # pylint:disable=too-few-public-methods,missing-
 
         self.obj = obj
         self.obj_class = obj.__class__.__name__
-        self.obj_id = str(getattr(self.instance, "id", None))
-        if hasattr(self.instance, "name"):
-            self.name = getattr(self.instance, "name")
+        self.obj_id = str(getattr(self.design_instance, "id", None))
+        if hasattr(self.design_instance, "name"):
+            self.name = getattr(self.design_instance, "name")
         else:
             self.name = None
         self.description = description
 
     def __str__(self):  # noqa:D105  # pylint:disable=missing-function-docstring
-        if isinstance(self.instance, models.Model):
+        if isinstance(self.design_instance, models.Model):
             string = self.obj_class + " "
             if self.name is not None:
                 string += '"' + self.name + '"' + ":"
@@ -36,7 +36,7 @@ class ObjDetails:  # noqa:D101  # pylint:disable=too-few-public-methods,missing-
                 string += self.description + ":"
             string += self.obj_id
             return string
-        if isinstance(self.instance, dict):
+        if isinstance(self.design_instance, dict):
             return str(self.obj)
         return self.description or self.name or self.obj_class
 

--- a/nautobot_design_builder/errors.py
+++ b/nautobot_design_builder/errors.py
@@ -52,7 +52,7 @@ class DesignModelError(Exception):
     @staticmethod
     def _model_str(model):
         instance_str = None
-        if not isinstance(model, Model) and not hasattr(model, "instance"):
+        if not isinstance(model, Model) and not hasattr(model, "design_instance"):
             if isclass(model):
                 return model.__name__
             try:
@@ -67,9 +67,9 @@ class DesignModelError(Exception):
 
         model_class = model.__class__
         # if it looks like a duck...
-        if hasattr(model, "instance"):
+        if hasattr(model, "design_instance"):
             model_class = model.model_class
-            model = model.instance
+            model = model.design_instance
 
         if model:
             try:
@@ -112,8 +112,8 @@ class DesignModelError(Exception):
         model = self.model
         while model is not None:
             path_msg.insert(0, DesignModelError._model_str(model))
-            if not isclass(model) and hasattr(model, "_parent"):
-                model = model._parent  # pylint:disable=protected-access
+            if not isclass(model) and hasattr(model, "_design_instance_parent"):
+                model = model._design_instance_parent  # pylint:disable=protected-access
             elif self.parent:
                 model = self.parent
                 self.parent = None

--- a/nautobot_design_builder/ext.py
+++ b/nautobot_design_builder/ext.py
@@ -195,12 +195,13 @@ class ReferenceExtension(AttributeExtension, ValueExtension):
         except KeyError:
             # pylint: disable=raise-missing-from
             raise DesignImplementationError(f"No ref named {key} has been saved in the design.")
-        if model_instance.instance and not model_instance.instance._state.adding:  # pylint: disable=protected-access
-            model_instance.instance.refresh_from_db()
+        adding = model_instance.design_instance._state.adding  # pylint: disable=protected-access
+        if model_instance.design_instance and not adding:
+            model_instance.design_instance.refresh_from_db()
         if attribute:
             # TODO: I think the result of the reduce operation needs to (potentially)
             # be wrapped up in a ModelInstance object
-            return reduce(getattr, [model_instance.instance, *attribute.split(".")])
+            return reduce(getattr, [model_instance.design_instance, *attribute.split(".")])
         return model_instance
 
 

--- a/nautobot_design_builder/tests/test_errors.py
+++ b/nautobot_design_builder/tests/test_errors.py
@@ -15,11 +15,11 @@ class TestDesignModelError(unittest.TestCase):
 
         def __init__(self, title="", parent=None):
             self.title = title
-            self.instance = self
+            self.design_instance = self
             self.model_class = self
             self._meta = self
             self.verbose_name = "verbose name"
-            self._parent = parent
+            self._design_instance_parent = parent
 
         def __str__(self):
             return self.title


### PR DESCRIPTION
Porting the ltm-1.6 fix to develop.

This fixes an issue where some Nautobot models have an `environment` or `metadata` field name. Almost all instance attributes in `ModelInstance` have been moved into the `ModelMetadata` class, and other fields have been prefixed to reduce the likelyhood of collision.
