### PR TITLE
feat: Error reporting for custom relationships that introduce duplicate fields

### DIFF
--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -326,7 +326,7 @@ class CableConnectionExtension(AttributeExtension, LookupMixin):
                 Q(termination_a_id=model_instance.design_instance.id)
                 | Q(termination_b_id=remote_instance.design_instance.id)
             ).first()
-            Cable = ModelInstance.factory(dcim.Cable)  # pylint:disable=invalid-name
+            Cable = self.environment.model_factory(dcim.Cable)  # pylint:disable=invalid-name
             if existing_cable:
                 if (
                     existing_cable.termination_a_id != model_instance.design_instance.id
@@ -536,8 +536,8 @@ class BGPPeeringExtension(AttributeExtension):
         try:
             from nautobot_bgp_models.models import PeerEndpoint, Peering  # pylint:disable=import-outside-toplevel
 
-            self.PeerEndpoint = ModelInstance.factory(PeerEndpoint)  # pylint:disable=invalid-name
-            self.Peering = ModelInstance.factory(Peering)  # pylint:disable=invalid-name
+            self.PeerEndpoint = self.environment.model_factory(PeerEndpoint)  # pylint:disable=invalid-name
+            self.Peering = self.environment.model_factory(Peering)  # pylint:disable=invalid-name
         except ModuleNotFoundError:
             # pylint:disable=raise-missing-from
             raise DesignImplementationError(

--- a/nautobot_design_builder/errors.py
+++ b/nautobot_design_builder/errors.py
@@ -219,3 +219,23 @@ class MultipleObjectsReturnedError(DesignQueryError):
     def __str__(self):
         """Error message with context."""
         return f"Multiple {self.model_str} objects matched query.\n\n{super().__str__()}"
+
+
+class FieldNameError(Exception):
+    """Raised when a custom relationship label would overwrite an existing field."""
+
+    def __init__(self, model_class, relationship, field_name):
+        """Create a FieldNameError.
+
+        Args:
+            model_class: The design builder model class that has the pre-existing field.
+            relationship: The relationship that would overwrite the field.
+            field_name: The name of the field that would be overwritten.
+        """
+        super().__init__(
+            (
+                f"Custom relationship `{relationship.label}` would overwrite the "
+                f"built-in field `{field_name}` on the `{model_class.__name__}` model. "
+                "This relationship will not be available in design builder."
+            )
+        )

--- a/nautobot_design_builder/tests/test_model_change_record.py
+++ b/nautobot_design_builder/tests/test_model_change_record.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, Mock
 from nautobot.extras.models import Secret
 from nautobot.dcim.models import Manufacturer, DeviceType
 
-from nautobot_design_builder.design import Environment, ModelInstance
+from nautobot_design_builder.design import Environment
 from nautobot_design_builder.errors import DesignValidationError
 
 from .test_model_deployment import BaseDeploymentTest
@@ -174,8 +174,9 @@ class TestChangeRecord(BaseDeploymentTest):  # pylint: disable=too-many-instance
         )
         secret.save()
         updated_params = {"key1": "initial-value", "key2": "changed-value"}
-        design_secret = ModelInstance.factory(Secret)(
-            Environment(),
+        environment = Environment()
+        design_secret = environment.model_factory(Secret)(
+            environment,
             {
                 "!create_or_update:name": "test secret 1",
                 "parameters": updated_params,

--- a/nautobot_design_builder/tests/testdata/custom_relationship_duplicate_field.yaml
+++ b/nautobot_design_builder/tests/testdata/custom_relationship_duplicate_field.yaml
@@ -1,0 +1,28 @@
+---
+extensions:
+  - "nautobot_design_builder.contrib.ext.LookupExtension"
+depends_on: "base_test.yaml"
+designs:
+  - relationships:
+      - label: "Prefix -> VLAN"
+        key: "prefix_vlan"
+        type: "one-to-many"
+        "!lookup:source_type":
+          app_label: "ipam"
+          model: "prefix"
+        source_label: "prefix"
+        "!lookup:destination_type":
+          app_label: "ipam"
+          model: "prefix"
+        destination_label: "vlan"
+    prefixes:
+      - locations:
+          - location:
+              "!get:name": "Site"
+        status__name: "Active"
+        prefix: "192.168.0.0/24"
+
+checks:
+  - model_exists:
+      model: "nautobot.ipam.models.Prefix"
+      query: {prefix: "192.168.0.0/24"}


### PR DESCRIPTION
This change provides an error message in the job log if a custom relationship would mask a built-in field. The behavior now protects the built-in field and will no longer overwrite the pre-existing field.

Fixes #154