### PR TITLE
Fix unit tests

### DIFF
--- a/nautobot_design_builder/tests/__init__.py
+++ b/nautobot_design_builder/tests/__init__.py
@@ -9,7 +9,6 @@ from unittest.mock import PropertyMock, patch
 
 from django.test import TestCase
 
-from nautobot.extras.utils import refresh_job_model_from_job_class
 from nautobot.extras.models import Job, JobResult
 from nautobot_design_builder.design_job import DesignJob
 
@@ -36,7 +35,7 @@ class DesignTestCase(TestCase):
 
     def get_mocked_job(self, design_class: Type[DesignJob]):
         """Create an instance of design_class and properly mock request and job_result for testing."""
-        job_model, _ = refresh_job_model_from_job_class(Job, design_class)
+        job_model = Job.objects.get(module_name=design_class.__module__, job_class_name=design_class.__name__)
         job = design_class()
         job.job_result = JobResult.objects.create(
             name="Fake Job Result",

--- a/nautobot_design_builder/tests/designs/test_designs.py
+++ b/nautobot_design_builder/tests/designs/test_designs.py
@@ -232,4 +232,5 @@ register_jobs(
     SimpleDesignDeploymentMode,
     SimpleDesignDeploymentModeMultipleObjects,
     SimpleDesignDeploymentModeUpdate,
+    SimpleDesignWithPostImplementation,
 )

--- a/nautobot_design_builder/tests/test_api.py
+++ b/nautobot_design_builder/tests/test_api.py
@@ -67,3 +67,10 @@ class TestChangeRecord(
 
     def test_list_objects_brief(self):
         """Brief is not supported for change records."""
+
+    def test_list_objects_depth_0(self):
+        """
+        Depth 0 is not supported for change records.
+        The core test checks that the response_data has only three fields: id/object_type/url. The
+        ChangeRecord model has more fields than that, so the test will fail.
+        """

--- a/nautobot_design_builder/tests/test_model_design.py
+++ b/nautobot_design_builder/tests/test_model_design.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from nautobot.extras.models import Job as JobModel
-from nautobot.extras.utils import refresh_job_model_from_job_class
 from nautobot_design_builder.tests import DesignTestCase
 
 from .designs import test_designs
@@ -46,7 +45,7 @@ class TestDesign(BaseDesignTest):
             test_designs.IntegrationDesign,
         ]
         for design in designs:
-            job, _ = refresh_job_model_from_job_class(JobModel, design)
+            job = JobModel.objects.get(module_name=design.__module__, job_class_name=design.__name__)
             design = models.Design.objects.get(job_id=job.id)
             self.assertEqual(job.name, design.name)
 

--- a/nautobot_design_builder/tests/util.py
+++ b/nautobot_design_builder/tests/util.py
@@ -34,7 +34,7 @@ def create_test_view_data():
     ]
     for i, job_class in enumerate(job_classes, 1):
         # Core models
-        job, _ = refresh_job_model_from_job_class(Job, job_class)
+        job = Job.objects.get(module_name=job_class.__module__, job_class_name=job_class.__name__)
         job_result = JobResult.objects.create(name=f"Test Result {i}", job_model=job)
         object_created_by_job = Tenant.objects.create(name=f"Tenant {i}")
 

--- a/nautobot_design_builder/tests/util.py
+++ b/nautobot_design_builder/tests/util.py
@@ -1,7 +1,6 @@
 """Utilities for setting up tests and test data."""
 
 from nautobot.extras.models import Status
-from nautobot.extras.utils import refresh_job_model_from_job_class
 from nautobot.extras.models import JobResult, Job
 from nautobot.tenancy.models import Tenant
 


### PR DESCRIPTION
This PR fixes the app's broken unit tests.

As part of the execution of unit tests, there is a call to the function `nautobot.extras.utils.refresh_job_from_job_class`. This function has an inconsistency because even though it treats the  `job_queue_class` parameter as optional, it actually uses it in multiple places. Thus, it really should be a mandatory parameter. This is also described in the docstring of that function. This seems to be broken since the signature of the function changed a couple of months ago in this PR (https://github.com/nautobot/nautobot/pull/6154/files#diff-68a8f5fd2548b2512fb27568ce73d7f29e3703f40873f450413f7b4f20e1fbf0).

From the perspective of a unit test from Design-Builder, we do not really have (or care) about the queue, especially during unit tests. Thus, I have changed the test to directly get the Job from the core model, this is possible because we already have the j`ob_class`.

Another option would be to use https://github.com/nautobot/nautobot/blob/develop/nautobot/core/testing/__init__.py#L92. However, we already have the job_class, and it would be unnecessary to get those values again..

Other blocking issues:
- There was a design that was not registered
- One core test does not apply to the ChangeRecord object due to the structure of that model. This probably broke due to some change in core in the last couple of months.