### PR TITLE
Next Available IP Extension

### DIFF
--- a/changes/234.added
+++ b/changes/234.added
@@ -1,1 +1,1 @@
-Added `next_available_ip` action tag
+Added `next_ip` action tag

--- a/changes/234.added
+++ b/changes/234.added
@@ -1,0 +1,1 @@
+Added `next_available_ip` action tag

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -687,9 +687,7 @@ class NextIpExtension(AttributeExtension):
             ```
         """
         if not isinstance(value, dict) and value.keys() >= {"parent"}:
-            raise DesignImplementationError(
-                "the next_ip tag must be supplied a dictionary with the `parent` key"
-            )
+            raise DesignImplementationError("the next_ip tag must be supplied a dictionary with the `parent` key")
 
         parent = value.pop("prefix", None)
         if parent is None:

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -689,7 +689,6 @@ class NextIpExtension(AttributeExtension):
         if not isinstance(value, dict) and value.keys() >= {"parent"}:
             raise DesignImplementationError(
                 "the next_ip tag must be supplied a dictionary with the `parent` key"
-                "the next_ip tag must be supplied a dictionary with the `parent` key"
             )
 
         parent = value.pop("prefix", None)

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -651,7 +651,6 @@ class NextIpExtension(AttributeExtension):
     """Provision the next prefix for a given set of parent prefixes."""
 
     tag = "next_ip"
-    tag = "next_ip"
 
     def attribute(self, *args, value: dict = None, model_instance: ModelInstance = None) -> None:
         """Provides the `!next_ip` attribute that will calculate the next available ip address in the provided parent prefix.
@@ -680,10 +679,8 @@ class NextIpExtension(AttributeExtension):
             ```yaml
             ip_addresses:
                 - "!next_ip":
-                - "!next_ip":
                         parent: "!ref:server-prefix"
                     status__name: "Active"
-                - "!next_ip":
                 - "!next_ip":
                         parent: "10.0.0.0/29"
                     status__name: "Active"

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -547,7 +547,7 @@ class BGPPeeringExtension(AttributeExtension):
         """
         super().__init__(environment)
         try:
-            from nautobot_bgp_models.models import (
+            from nautobot_bgp_models.models import (  # pylint:disable=import-outside-toplevel
                 PeerEndpoint,
                 Peering,
             )
@@ -694,7 +694,7 @@ class NextIpExtension(AttributeExtension):
         parent = value.pop("parent", None)
         if parent is None:
             raise DesignImplementationError("the child_prefix tag requires a parent")
-        elif isinstance(parent, ModelInstance):
+        if isinstance(parent, ModelInstance):
             prefix = str(parent.design_instance.prefix)
         elif isinstance(parent, str):
             prefix = parent.strip()

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -54,9 +54,7 @@ class LookupMixin:
             queryset = model_class.objects
         except ContentType.DoesNotExist:
             # pylint: disable=raise-missing-from
-            raise DesignImplementationError(
-                f"Could not find model class for {model_class}"
-            )
+            raise DesignImplementationError(f"Could not find model class for {model_class}")
 
         return self.lookup(queryset, query)
 
@@ -149,9 +147,7 @@ class LookupMixin:
             raise DoesNotExistError(queryset.model, query_filter=query, parent=parent)
         except MultipleObjectsReturned:
             # pylint: disable=raise-missing-from
-            raise MultipleObjectsReturnedError(
-                queryset.model, query_filter=query, parent=parent
-            )
+            raise MultipleObjectsReturnedError(queryset.model, query_filter=query, parent=parent)
 
 
 class LookupExtension(AttributeExtension, LookupMixin):
@@ -159,9 +155,7 @@ class LookupExtension(AttributeExtension, LookupMixin):
 
     tag = "lookup"
 
-    def attribute(
-        self, *args, value, model_instance
-    ) -> None:  # pylint:disable=arguments-differ
+    def attribute(self, *args, value, model_instance) -> None:  # pylint:disable=arguments-differ
         """Provides the `!lookup` attribute that will lookup an instance.
 
         This action tag can be used to lookup an object in the database and
@@ -209,9 +203,7 @@ class LookupExtension(AttributeExtension, LookupMixin):
         elif isinstance(value, dict):
             query = value
         else:
-            raise DesignImplementationError(
-                "the lookup requires a query attribute and value or a query dictionary."
-            )
+            raise DesignImplementationError("the lookup requires a query attribute and value or a query dictionary.")
 
         content_type = query.pop("content-type", None)
         if content_type is None:
@@ -266,9 +258,7 @@ class CableConnectionExtension(AttributeExtension, LookupMixin):
 
         return query_managers
 
-    def attribute(
-        self, *args, value=None, model_instance: ModelInstance = None
-    ) -> None:
+    def attribute(self, *args, value=None, model_instance: ModelInstance = None) -> None:
         """Connect a cable termination to another cable termination.
 
         Args:
@@ -349,18 +339,13 @@ class CableConnectionExtension(AttributeExtension, LookupMixin):
                 Q(termination_a_id=model_instance.design_instance.id)
                 | Q(termination_b_id=remote_instance.design_instance.id)
             ).first()
-            Cable = self.environment.model_factory(
-                dcim.Cable
-            )  # pylint:disable=invalid-name
+            Cable = self.environment.model_factory(dcim.Cable)  # pylint:disable=invalid-name
             if existing_cable:
                 if (
                     existing_cable.termination_a_id != model_instance.design_instance.id
-                    or existing_cable.termination_b_id
-                    != remote_instance.design_instance.id
+                    or existing_cable.termination_b_id != remote_instance.design_instance.id
                 ):
-                    self.environment.decommission_object(
-                        existing_cable.id, f"Cable {existing_cable.id}"
-                    )
+                    self.environment.decommission_object(existing_cable.id, f"Cable {existing_cable.id}")
             cable = Cable(self.environment, cable_attributes)
             cable.save()
 
@@ -372,9 +357,7 @@ class NextPrefixExtension(AttributeExtension):
 
     tag = "next_prefix"
 
-    def attribute(
-        self, *args, value: dict = None, model_instance: ModelInstance = None
-    ) -> None:
+    def attribute(self, *args, value: dict = None, model_instance: ModelInstance = None) -> None:
         """Provides the `!next_prefix` attribute that will calculate the next available prefix.
 
         Args:
@@ -410,23 +393,17 @@ class NextPrefixExtension(AttributeExtension):
             ```
         """
         if not isinstance(value, dict):
-            raise DesignImplementationError(
-                "the next_prefix tag requires a dictionary of arguments"
-            )
+            raise DesignImplementationError("the next_prefix tag requires a dictionary of arguments")
         identified_by = value.pop("identified_by", None)
         if identified_by:
             try:
-                model_instance.design_instance = (
-                    model_instance.relationship_manager.get(**identified_by)
-                )
+                model_instance.design_instance = model_instance.relationship_manager.get(**identified_by)
                 return None
             except ObjectDoesNotExist:
                 pass
         length = value.pop("length", None)
         if length is None:
-            raise DesignImplementationError(
-                "the next_prefix tag requires a prefix length"
-            )
+            raise DesignImplementationError("the next_prefix tag requires a prefix length")
 
         if len(value) == 0:
             raise DesignImplementationError("no search criteria specified for prefixes")
@@ -438,9 +415,7 @@ class NextPrefixExtension(AttributeExtension):
             if isinstance(prefixes, str):
                 prefixes = [prefixes]
             elif not isinstance(prefixes, list):
-                raise DesignImplementationError(
-                    "Prefixes should be a string (single prefix) or a list."
-                )
+                raise DesignImplementationError("Prefixes should be a string (single prefix) or a list.")
 
             for prefix_str in prefixes:
                 prefix_str = prefix_str.strip()
@@ -472,14 +447,10 @@ class NextPrefixExtension(AttributeExtension):
         """
         length = int(length)
         for requested_prefix in prefixes:
-            for (
-                available_prefix
-            ) in requested_prefix.get_available_prefixes().iter_cidrs():
+            for available_prefix in requested_prefix.get_available_prefixes().iter_cidrs():
                 if available_prefix.prefixlen <= length:
                     return f"{available_prefix.network}/{length}"
-        raise DesignImplementationError(
-            f"No available prefixes could be found from {list(map(str, prefixes))}"
-        )
+        raise DesignImplementationError(f"No available prefixes could be found from {list(map(str, prefixes))}")
 
 
 class ChildPrefixExtension(AttributeExtension):
@@ -487,9 +458,7 @@ class ChildPrefixExtension(AttributeExtension):
 
     tag = "child_prefix"
 
-    def attribute(
-        self, *args, value: dict = None, model_instance: "ModelInstance" = None
-    ) -> None:
+    def attribute(self, *args, value: dict = None, model_instance: "ModelInstance" = None) -> None:
         """Provides the `!child_prefix` attribute.
 
         !child_prefix calculates a child prefix using a parent prefix
@@ -536,9 +505,7 @@ class ChildPrefixExtension(AttributeExtension):
             ```
         """
         if not isinstance(value, dict):
-            raise DesignImplementationError(
-                "the child_prefix tag requires a dictionary of arguments"
-            )
+            raise DesignImplementationError("the child_prefix tag requires a dictionary of arguments")
 
         action = value.pop("action", "")
 
@@ -548,9 +515,7 @@ class ChildPrefixExtension(AttributeExtension):
         if isinstance(parent, ModelInstance):
             parent = str(parent.design_instance.prefix)
         elif not isinstance(parent, str):
-            raise DesignImplementationError(
-                "parent prefix must be either a previously created object or a string."
-            )
+            raise DesignImplementationError("parent prefix must be either a previously created object or a string.")
 
         offset = value.pop("offset", None)
         if offset is None:
@@ -561,9 +526,7 @@ class ChildPrefixExtension(AttributeExtension):
 
         if action:
             model_instance.design_metadata.action = action
-            model_instance.design_metadata.filter[attr] = str(
-                network_offset(parent, offset)
-            )
+            model_instance.design_metadata.filter[attr] = str(network_offset(parent, offset))
             return None
         return attr, str(network_offset(parent, offset))
 
@@ -589,21 +552,15 @@ class BGPPeeringExtension(AttributeExtension):
                 Peering,
             )
 
-            self.PeerEndpoint = self.environment.model_factory(
-                PeerEndpoint
-            )  # pylint:disable=invalid-name
-            self.Peering = self.environment.model_factory(
-                Peering
-            )  # pylint:disable=invalid-name
+            self.PeerEndpoint = self.environment.model_factory(PeerEndpoint)  # pylint:disable=invalid-name
+            self.Peering = self.environment.model_factory(Peering)  # pylint:disable=invalid-name
         except ModuleNotFoundError:
             # pylint:disable=raise-missing-from
             raise DesignImplementationError(
                 "the `bgp_peering` tag can only be used when the bgp models app is installed."
             )
 
-    def attribute(
-        self, *args, value=None, model_instance: ModelInstance = None
-    ) -> None:
+    def attribute(self, *args, value=None, model_instance: ModelInstance = None) -> None:
         """This attribute tag creates or updates a BGP peering for two endpoints.
 
         !bgp_peering will take an `endpoint_a` and `endpoint_z` argument to correctly
@@ -646,9 +603,7 @@ class BGPPeeringExtension(AttributeExtension):
           status__name: "Active"
         ```
         """
-        if not (
-            isinstance(value, dict) and value.keys() >= {"endpoint_a", "endpoint_z"}
-        ):
+        if not (isinstance(value, dict) and value.keys() >= {"endpoint_a", "endpoint_z"}):
             raise DesignImplementationError(
                 "bgp peerings must be supplied a dictionary with `endpoint_a` and `endpoint_z`."
             )
@@ -698,9 +653,7 @@ class NextIpExtension(AttributeExtension):
     tag = "next_ip"
     tag = "next_ip"
 
-    def attribute(
-        self, *args, value: dict = None, model_instance: ModelInstance = None
-    ) -> None:
+    def attribute(self, *args, value: dict = None, model_instance: ModelInstance = None) -> None:
         """Provides the `!next_ip` attribute that will calculate the next available ip address in the provided parent prefix.
 
         Args:
@@ -750,9 +703,7 @@ class NextIpExtension(AttributeExtension):
         elif isinstance(parent, str):
             prefix = parent.strip()
         elif not isinstance(parent, str):
-            raise DesignImplementationError(
-                "parent prefix must be either a previously created object or a string."
-            )
+            raise DesignImplementationError("parent prefix must be either a previously created object or a string.")
         else:
             raise DesignImplementationError("unexpected error processing parent prefix")
 
@@ -770,9 +721,7 @@ class NextIpExtension(AttributeExtension):
 
         prefix = Prefix.objects.filter(query).first()
         if not prefix:
-            raise DesignImplementationError(
-                f"No matching prefix found for query {query}"
-            )
+            raise DesignImplementationError(f"No matching prefix found for query {query}")
         return {
             "host": self._get_next(prefix),
             "mask_length": prefix.prefix_length,
@@ -791,7 +740,5 @@ class NextIpExtension(AttributeExtension):
         """
         available_ips = prefix.get_available_ips()
         if not available_ips:
-            raise DesignImplementationError(
-                f"No available ip address could be found from {prefix}"
-            )
+            raise DesignImplementationError(f"No available ip address could be found from {prefix}")
         return f"{next(iter(available_ips))}"

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -695,9 +695,9 @@ class NextIpExtension(AttributeExtension):
                 "the next_ip tag must be supplied a dictionary with the `parent` key"
             )
 
-        parent = value.pop("parent", None)
+        parent = value.pop("prefix", None)
         if parent is None:
-            raise DesignImplementationError("the child_prefix tag requires a parent")
+            raise DesignImplementationError("the next_ip tag requires a parent")
         if isinstance(parent, ModelInstance):
             prefix = str(parent.design_instance.prefix)
         elif isinstance(parent, str):

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -653,12 +653,12 @@ class NextIpExtension(AttributeExtension):
     tag = "next_available_ip"
 
     def attribute(self, *args, value: dict = None, model_instance: ModelInstance = None) -> None:
-        """Provides the `!next_available_ip` attribute that will calculate the next available ip address in the provided prefix.
+        """Provides the `!next_available_ip` attribute that will calculate the next available ip address in the provided parent prefix.
 
         Args:
             *args: Any additional arguments following the tag name. These are `:` delimited.
 
-            value: A filter describing the parent prefix to provision from. If `prefix`
+            value: A filter describing the parent prefix to provision from. If `parent`
                 is one of the query keys then the network and prefix length will be
                 split and used as query arguments for the underlying Prefix object.
                 All other keys are passed on to the query filter directly.
@@ -672,56 +672,56 @@ class NextIpExtension(AttributeExtension):
 
         Returns:
             dict: Dictionary that can be used by the design.Builder to create the IP Address.
-                The dictionary will contain "host" and "mask_length" keys.
+                The dictionary will contain "host", "mask_length", and "parent__id" keys.
                 "mask_length" is the prefix length of the parent prefix.
 
         Example:
             ```yaml
             ip_addresses:
                 - "!next_available_ip":
-                        prefix: "!ref:server-prefix"
-                    parent: "!ref:server-prefix"
+                        parent: "!ref:server-prefix"
                     status__name: "Active"
                 - "!next_available_ip":
-                        prefix: "10.0.0.0/29"
-                    parent: "!ref:server-prefix"
+                        parent: "10.0.0.0/29"
                     status__name: "Active"
             ```
         """
-        if not isinstance(value, dict):
-            raise DesignImplementationError("the next_available_ip tag requires a dictionary of arguments")
-
-        if len(value) == 0:
-            raise DesignImplementationError("no search criteria specified for ip address")
-
-        query = Q(**value)
-        if "prefix" in value:
-            prefix = value.pop("prefix")
-            prefix_q = []
-            if isinstance(prefix, str):
-                pass
-            elif isinstance(prefix, ModelInstance):
-                prefix = str(prefix.design_instance.prefix)
-            else:
-                raise DesignImplementationError(
-                    "Prefix key should contain a string (CIDR notation) or a reference to a single prefix."
-                )
-
-            prefix_str = prefix.strip()
-            prefix = netaddr.IPNetwork(prefix_str)
-            prefix_q.append(
-                Q(
-                    prefix_length=prefix.prefixlen,
-                    network=prefix.network,
-                    broadcast=prefix.broadcast,
-                )
+        if not isinstance(value, dict) and value.keys() >= {"parent"}:
+            raise DesignImplementationError(
+                "the next_available_ip tag must be supplied a dictionary with the `parent` key"
             )
-            query = Q(**value) & reduce(operator.or_, prefix_q)
 
-        prefix = Prefix.objects.filter(query)
+        parent = value.pop("parent", None)
+        if parent is None:
+            raise DesignImplementationError("the child_prefix tag requires a parent")
+        elif isinstance(parent, ModelInstance):
+            prefix = str(parent.design_instance.prefix)
+        elif isinstance(parent, str):
+            prefix = parent.strip()
+        elif not isinstance(parent, str):
+            raise DesignImplementationError("parent prefix must be either a previously created object or a string.")
+        else:
+            raise DesignImplementationError("unexpected error processing parent prefix")
+
+        prefix = netaddr.IPNetwork(prefix)
+        query = Q(**value)
+        prefix_q = []
+        prefix_q.append(
+            Q(
+                prefix_length=prefix.prefixlen,
+                network=prefix.network,
+                broadcast=prefix.broadcast,
+            )
+        )
+        query = Q(**value) & reduce(operator.or_, prefix_q)
+
+        prefix = Prefix.objects.filter(query).first()
+        if not prefix:
+            raise DesignImplementationError(f"No matching prefix found for query {query}")
         return {
-            "host": self._get_next(prefix.first()),
-            "mask_length": prefix.first().prefix_length,
+            "host": self._get_next(prefix),
+            "mask_length": prefix.prefix_length,
+            "parent__id": prefix.id,
         }
 
     @staticmethod

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -650,10 +650,10 @@ class BGPPeeringExtension(AttributeExtension):
 class NextIpExtension(AttributeExtension):
     """Provision the next prefix for a given set of parent prefixes."""
 
-    tag = "next_available_ip"
+    tag = "next_ip"
 
     def attribute(self, *args, value: dict = None, model_instance: ModelInstance = None) -> None:
-        """Provides the `!next_available_ip` attribute that will calculate the next available ip address in the provided parent prefix.
+        """Provides the `!next_ip` attribute that will calculate the next available ip address in the provided parent prefix.
 
         Args:
             *args: Any additional arguments following the tag name. These are `:` delimited.
@@ -678,17 +678,17 @@ class NextIpExtension(AttributeExtension):
         Example:
             ```yaml
             ip_addresses:
-                - "!next_available_ip":
+                - "!next_ip":
                         parent: "!ref:server-prefix"
                     status__name: "Active"
-                - "!next_available_ip":
+                - "!next_ip":
                         parent: "10.0.0.0/29"
                     status__name: "Active"
             ```
         """
         if not isinstance(value, dict) and value.keys() >= {"parent"}:
             raise DesignImplementationError(
-                "the next_available_ip tag must be supplied a dictionary with the `parent` key"
+                "the next_ip tag must be supplied a dictionary with the `parent` key"
             )
 
         parent = value.pop("parent", None)

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -6,14 +6,22 @@ from typing import Any, Dict, Iterator, Tuple
 
 import netaddr
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import FieldError, MultipleObjectsReturned, ObjectDoesNotExist
+from django.core.exceptions import (
+    FieldError,
+    MultipleObjectsReturned,
+    ObjectDoesNotExist,
+)
 from django.db.models import Q
 from nautobot.circuits import models as circuits
 from nautobot.dcim import models as dcim
 from nautobot.ipam.models import Prefix
 
 from nautobot_design_builder.design import Environment, ModelInstance, ModelMetadata
-from nautobot_design_builder.errors import DesignImplementationError, DoesNotExistError, MultipleObjectsReturnedError
+from nautobot_design_builder.errors import (
+    DesignImplementationError,
+    DoesNotExistError,
+    MultipleObjectsReturnedError,
+)
 from nautobot_design_builder.ext import AttributeExtension
 from nautobot_design_builder.jinja_filters import network_offset
 
@@ -231,7 +239,12 @@ class CableConnectionExtension(AttributeExtension, LookupMixin):
         Returns:
             list: A list of query managers for types that can be connected to.
         """
-        interface_types = (dcim.FrontPort, dcim.RearPort, dcim.Interface, circuits.CircuitTermination)
+        interface_types = (
+            dcim.FrontPort,
+            dcim.RearPort,
+            dcim.Interface,
+            circuits.CircuitTermination,
+        )
         query_managers = None
         if issubclass(endpoint_type, interface_types):
             query_managers = [it.objects for it in interface_types]
@@ -303,7 +316,9 @@ class CableConnectionExtension(AttributeExtension, LookupMixin):
                 if not query_managers:
                     # pylint:disable=raise-missing-from
                     raise DoesNotExistError(
-                        model=model_instance.model_class, parent=model_instance, query_filter=termination_query
+                        model=model_instance.model_class,
+                        parent=model_instance,
+                        query_filter=termination_query,
                     )
 
         def connect():
@@ -532,7 +547,10 @@ class BGPPeeringExtension(AttributeExtension):
         """
         super().__init__(environment)
         try:
-            from nautobot_bgp_models.models import PeerEndpoint, Peering  # pylint:disable=import-outside-toplevel
+            from nautobot_bgp_models.models import (
+                PeerEndpoint,
+                Peering,
+            )
 
             self.PeerEndpoint = self.environment.model_factory(PeerEndpoint)  # pylint:disable=invalid-name
             self.Peering = self.environment.model_factory(Peering)  # pylint:disable=invalid-name
@@ -627,3 +645,96 @@ class BGPPeeringExtension(AttributeExtension):
 
         model_instance.connect(ModelMetadata.POST_SAVE, post_save)
         return retval
+
+
+class NextIpExtension(AttributeExtension):
+    """Provision the next prefix for a given set of parent prefixes."""
+
+    tag = "next_available_ip"
+
+    def attribute(self, *args, value: dict = None, model_instance: ModelInstance = None) -> None:
+        """Provides the `!next_available_ip` attribute that will calculate the next available ip address in the provided prefix.
+
+        Args:
+            *args: Any additional arguments following the tag name. These are `:` delimited.
+
+            value: A filter describing the parent prefix to provision from. If `prefix`
+                is one of the query keys then the network and prefix length will be
+                split and used as query arguments for the underlying Prefix object.
+                All other keys are passed on to the query filter directly.
+
+            model_instance (ModelInstance): The IP address that is to be updated.
+
+        Raises:
+            DesignImplementationError: if value is not a dictionary, the prefix is improperly formatted
+                or no query arguments were given. This error is also raised if the supplied parent
+                prefixes are all full.
+
+        Returns:
+            dict: Dictionary that can be used by the design.Builder to create the IP Address.
+                The dictionary will contain "host" and "mask_length" keys.
+                "mask_length" is the prefix length of the parent prefix.
+
+        Example:
+            ```yaml
+            ip_addresses:
+                - "!next_available_ip":
+                        prefix: "!ref:server-prefix"
+                    parent: "!ref:server-prefix"
+                    status__name: "Active"
+                - "!next_available_ip":
+                        prefix: "10.0.0.0/29"
+                    parent: "!ref:server-prefix"
+                    status__name: "Active"
+            ```
+        """
+        if not isinstance(value, dict):
+            raise DesignImplementationError("the next_available_ip tag requires a dictionary of arguments")
+
+        if len(value) == 0:
+            raise DesignImplementationError("no search criteria specified for ip address")
+
+        query = Q(**value)
+        if "prefix" in value:
+            prefix = value.pop("prefix")
+            prefix_q = []
+            if isinstance(prefix, str):
+                pass
+            elif isinstance(prefix, ModelInstance):
+                prefix = str(prefix.design_instance.prefix)
+            else:
+                raise DesignImplementationError(
+                    "Prefix key should contain a string (CIDR notation) or a reference to a single prefix."
+                )
+
+            prefix_str = prefix.strip()
+            prefix = netaddr.IPNetwork(prefix_str)
+            prefix_q.append(
+                Q(
+                    prefix_length=prefix.prefixlen,
+                    network=prefix.network,
+                    broadcast=prefix.broadcast,
+                )
+            )
+            query = Q(**value) & reduce(operator.or_, prefix_q)
+
+        prefix = Prefix.objects.filter(query)
+        return {
+            "host": self._get_next(prefix.first()),
+            "mask_length": prefix.first().prefix_length,
+        }
+
+    @staticmethod
+    def _get_next(prefix) -> str:
+        """Return the next available ip from a parent prefix.
+
+        Args:
+            prefix (Prefix): prefix to search for available ips.
+
+        Returns:
+            str: The next available ip
+        """
+        available_ips = prefix.get_available_ips()
+        if not available_ips:
+            raise DesignImplementationError(f"No available ip address could be found from {prefix}")
+        return f"{next(iter(available_ips))}"

--- a/nautobot_design_builder/contrib/ext.py
+++ b/nautobot_design_builder/contrib/ext.py
@@ -54,7 +54,9 @@ class LookupMixin:
             queryset = model_class.objects
         except ContentType.DoesNotExist:
             # pylint: disable=raise-missing-from
-            raise DesignImplementationError(f"Could not find model class for {model_class}")
+            raise DesignImplementationError(
+                f"Could not find model class for {model_class}"
+            )
 
         return self.lookup(queryset, query)
 
@@ -147,7 +149,9 @@ class LookupMixin:
             raise DoesNotExistError(queryset.model, query_filter=query, parent=parent)
         except MultipleObjectsReturned:
             # pylint: disable=raise-missing-from
-            raise MultipleObjectsReturnedError(queryset.model, query_filter=query, parent=parent)
+            raise MultipleObjectsReturnedError(
+                queryset.model, query_filter=query, parent=parent
+            )
 
 
 class LookupExtension(AttributeExtension, LookupMixin):
@@ -155,7 +159,9 @@ class LookupExtension(AttributeExtension, LookupMixin):
 
     tag = "lookup"
 
-    def attribute(self, *args, value, model_instance) -> None:  # pylint:disable=arguments-differ
+    def attribute(
+        self, *args, value, model_instance
+    ) -> None:  # pylint:disable=arguments-differ
         """Provides the `!lookup` attribute that will lookup an instance.
 
         This action tag can be used to lookup an object in the database and
@@ -203,7 +209,9 @@ class LookupExtension(AttributeExtension, LookupMixin):
         elif isinstance(value, dict):
             query = value
         else:
-            raise DesignImplementationError("the lookup requires a query attribute and value or a query dictionary.")
+            raise DesignImplementationError(
+                "the lookup requires a query attribute and value or a query dictionary."
+            )
 
         content_type = query.pop("content-type", None)
         if content_type is None:
@@ -258,7 +266,9 @@ class CableConnectionExtension(AttributeExtension, LookupMixin):
 
         return query_managers
 
-    def attribute(self, *args, value=None, model_instance: ModelInstance = None) -> None:
+    def attribute(
+        self, *args, value=None, model_instance: ModelInstance = None
+    ) -> None:
         """Connect a cable termination to another cable termination.
 
         Args:
@@ -339,13 +349,18 @@ class CableConnectionExtension(AttributeExtension, LookupMixin):
                 Q(termination_a_id=model_instance.design_instance.id)
                 | Q(termination_b_id=remote_instance.design_instance.id)
             ).first()
-            Cable = self.environment.model_factory(dcim.Cable)  # pylint:disable=invalid-name
+            Cable = self.environment.model_factory(
+                dcim.Cable
+            )  # pylint:disable=invalid-name
             if existing_cable:
                 if (
                     existing_cable.termination_a_id != model_instance.design_instance.id
-                    or existing_cable.termination_b_id != remote_instance.design_instance.id
+                    or existing_cable.termination_b_id
+                    != remote_instance.design_instance.id
                 ):
-                    self.environment.decommission_object(existing_cable.id, f"Cable {existing_cable.id}")
+                    self.environment.decommission_object(
+                        existing_cable.id, f"Cable {existing_cable.id}"
+                    )
             cable = Cable(self.environment, cable_attributes)
             cable.save()
 
@@ -357,7 +372,9 @@ class NextPrefixExtension(AttributeExtension):
 
     tag = "next_prefix"
 
-    def attribute(self, *args, value: dict = None, model_instance: ModelInstance = None) -> None:
+    def attribute(
+        self, *args, value: dict = None, model_instance: ModelInstance = None
+    ) -> None:
         """Provides the `!next_prefix` attribute that will calculate the next available prefix.
 
         Args:
@@ -393,17 +410,23 @@ class NextPrefixExtension(AttributeExtension):
             ```
         """
         if not isinstance(value, dict):
-            raise DesignImplementationError("the next_prefix tag requires a dictionary of arguments")
+            raise DesignImplementationError(
+                "the next_prefix tag requires a dictionary of arguments"
+            )
         identified_by = value.pop("identified_by", None)
         if identified_by:
             try:
-                model_instance.design_instance = model_instance.relationship_manager.get(**identified_by)
+                model_instance.design_instance = (
+                    model_instance.relationship_manager.get(**identified_by)
+                )
                 return None
             except ObjectDoesNotExist:
                 pass
         length = value.pop("length", None)
         if length is None:
-            raise DesignImplementationError("the next_prefix tag requires a prefix length")
+            raise DesignImplementationError(
+                "the next_prefix tag requires a prefix length"
+            )
 
         if len(value) == 0:
             raise DesignImplementationError("no search criteria specified for prefixes")
@@ -415,7 +438,9 @@ class NextPrefixExtension(AttributeExtension):
             if isinstance(prefixes, str):
                 prefixes = [prefixes]
             elif not isinstance(prefixes, list):
-                raise DesignImplementationError("Prefixes should be a string (single prefix) or a list.")
+                raise DesignImplementationError(
+                    "Prefixes should be a string (single prefix) or a list."
+                )
 
             for prefix_str in prefixes:
                 prefix_str = prefix_str.strip()
@@ -447,10 +472,14 @@ class NextPrefixExtension(AttributeExtension):
         """
         length = int(length)
         for requested_prefix in prefixes:
-            for available_prefix in requested_prefix.get_available_prefixes().iter_cidrs():
+            for (
+                available_prefix
+            ) in requested_prefix.get_available_prefixes().iter_cidrs():
                 if available_prefix.prefixlen <= length:
                     return f"{available_prefix.network}/{length}"
-        raise DesignImplementationError(f"No available prefixes could be found from {list(map(str, prefixes))}")
+        raise DesignImplementationError(
+            f"No available prefixes could be found from {list(map(str, prefixes))}"
+        )
 
 
 class ChildPrefixExtension(AttributeExtension):
@@ -458,7 +487,9 @@ class ChildPrefixExtension(AttributeExtension):
 
     tag = "child_prefix"
 
-    def attribute(self, *args, value: dict = None, model_instance: "ModelInstance" = None) -> None:
+    def attribute(
+        self, *args, value: dict = None, model_instance: "ModelInstance" = None
+    ) -> None:
         """Provides the `!child_prefix` attribute.
 
         !child_prefix calculates a child prefix using a parent prefix
@@ -505,7 +536,9 @@ class ChildPrefixExtension(AttributeExtension):
             ```
         """
         if not isinstance(value, dict):
-            raise DesignImplementationError("the child_prefix tag requires a dictionary of arguments")
+            raise DesignImplementationError(
+                "the child_prefix tag requires a dictionary of arguments"
+            )
 
         action = value.pop("action", "")
 
@@ -515,7 +548,9 @@ class ChildPrefixExtension(AttributeExtension):
         if isinstance(parent, ModelInstance):
             parent = str(parent.design_instance.prefix)
         elif not isinstance(parent, str):
-            raise DesignImplementationError("parent prefix must be either a previously created object or a string.")
+            raise DesignImplementationError(
+                "parent prefix must be either a previously created object or a string."
+            )
 
         offset = value.pop("offset", None)
         if offset is None:
@@ -526,7 +561,9 @@ class ChildPrefixExtension(AttributeExtension):
 
         if action:
             model_instance.design_metadata.action = action
-            model_instance.design_metadata.filter[attr] = str(network_offset(parent, offset))
+            model_instance.design_metadata.filter[attr] = str(
+                network_offset(parent, offset)
+            )
             return None
         return attr, str(network_offset(parent, offset))
 
@@ -552,15 +589,21 @@ class BGPPeeringExtension(AttributeExtension):
                 Peering,
             )
 
-            self.PeerEndpoint = self.environment.model_factory(PeerEndpoint)  # pylint:disable=invalid-name
-            self.Peering = self.environment.model_factory(Peering)  # pylint:disable=invalid-name
+            self.PeerEndpoint = self.environment.model_factory(
+                PeerEndpoint
+            )  # pylint:disable=invalid-name
+            self.Peering = self.environment.model_factory(
+                Peering
+            )  # pylint:disable=invalid-name
         except ModuleNotFoundError:
             # pylint:disable=raise-missing-from
             raise DesignImplementationError(
                 "the `bgp_peering` tag can only be used when the bgp models app is installed."
             )
 
-    def attribute(self, *args, value=None, model_instance: ModelInstance = None) -> None:
+    def attribute(
+        self, *args, value=None, model_instance: ModelInstance = None
+    ) -> None:
         """This attribute tag creates or updates a BGP peering for two endpoints.
 
         !bgp_peering will take an `endpoint_a` and `endpoint_z` argument to correctly
@@ -603,7 +646,9 @@ class BGPPeeringExtension(AttributeExtension):
           status__name: "Active"
         ```
         """
-        if not (isinstance(value, dict) and value.keys() >= {"endpoint_a", "endpoint_z"}):
+        if not (
+            isinstance(value, dict) and value.keys() >= {"endpoint_a", "endpoint_z"}
+        ):
             raise DesignImplementationError(
                 "bgp peerings must be supplied a dictionary with `endpoint_a` and `endpoint_z`."
             )
@@ -650,10 +695,12 @@ class BGPPeeringExtension(AttributeExtension):
 class NextIpExtension(AttributeExtension):
     """Provision the next prefix for a given set of parent prefixes."""
 
-    tag = "next_available_ip"
+    tag = "next_ip"
 
-    def attribute(self, *args, value: dict = None, model_instance: ModelInstance = None) -> None:
-        """Provides the `!next_available_ip` attribute that will calculate the next available ip address in the provided parent prefix.
+    def attribute(
+        self, *args, value: dict = None, model_instance: ModelInstance = None
+    ) -> None:
+        """Provides the `!next_ip` attribute that will calculate the next available ip address in the provided parent prefix.
 
         Args:
             *args: Any additional arguments following the tag name. These are `:` delimited.
@@ -678,17 +725,17 @@ class NextIpExtension(AttributeExtension):
         Example:
             ```yaml
             ip_addresses:
-                - "!next_available_ip":
+                - "!next_ip":
                         parent: "!ref:server-prefix"
                     status__name: "Active"
-                - "!next_available_ip":
+                - "!next_ip":
                         parent: "10.0.0.0/29"
                     status__name: "Active"
             ```
         """
         if not isinstance(value, dict) and value.keys() >= {"parent"}:
             raise DesignImplementationError(
-                "the next_available_ip tag must be supplied a dictionary with the `parent` key"
+                "the next_ip tag must be supplied a dictionary with the `parent` key"
             )
 
         parent = value.pop("parent", None)
@@ -699,7 +746,9 @@ class NextIpExtension(AttributeExtension):
         elif isinstance(parent, str):
             prefix = parent.strip()
         elif not isinstance(parent, str):
-            raise DesignImplementationError("parent prefix must be either a previously created object or a string.")
+            raise DesignImplementationError(
+                "parent prefix must be either a previously created object or a string."
+            )
         else:
             raise DesignImplementationError("unexpected error processing parent prefix")
 
@@ -717,7 +766,9 @@ class NextIpExtension(AttributeExtension):
 
         prefix = Prefix.objects.filter(query).first()
         if not prefix:
-            raise DesignImplementationError(f"No matching prefix found for query {query}")
+            raise DesignImplementationError(
+                f"No matching prefix found for query {query}"
+            )
         return {
             "host": self._get_next(prefix),
             "mask_length": prefix.prefix_length,
@@ -736,5 +787,7 @@ class NextIpExtension(AttributeExtension):
         """
         available_ips = prefix.get_available_ips()
         if not available_ips:
-            raise DesignImplementationError(f"No available ip address could be found from {prefix}")
+            raise DesignImplementationError(
+                f"No available ip address could be found from {prefix}"
+            )
         return f"{next(iter(available_ips))}"

--- a/nautobot_design_builder/contrib/tests/testdata/next_available_ip.yaml
+++ b/nautobot_design_builder/contrib/tests/testdata/next_available_ip.yaml
@@ -27,14 +27,11 @@ designs:
         "!ref": "server-prefix"
     ip_addresses:
       - "!next_available_ip":
-          prefix: "!ref:server-prefix"
-        mask_length: 30
-        parent: "!ref:server-prefix"
+          parent: "!ref:server-prefix"
         status__name: "Active"
         tenant__name: "Nautobot Airports"
       - "!next_available_ip":
-          prefix: "10.0.0.0/29"
-        parent: "!ref:server-prefix"
+          parent: "10.0.0.0/29"
         status__name: "Active"
         tenant__name: "Nautobot Airports"
 checks:

--- a/nautobot_design_builder/contrib/tests/testdata/next_available_ip.yaml
+++ b/nautobot_design_builder/contrib/tests/testdata/next_available_ip.yaml
@@ -1,0 +1,49 @@
+---
+extensions:
+  - "nautobot_design_builder.contrib.ext.NextIpExtension"
+designs:
+  - prefixes:
+      - prefix: "10.0.0.0/29"
+        status__name: "Active"
+        "!ref": "server-prefix"
+    ip_addresses:
+      - host: "10.0.0.1"
+        mask_length: 30
+        parent: "!ref:server-prefix"
+        status__name: "Active"
+  - tenants:
+      - name: "Nautobot Airports"
+    roles:
+      - name: "Video"
+        content_types:
+          - "!get:app_label": "ipam"
+            "!get:model": "prefix"
+      - name: "Servers"
+        content_types:
+          - "!get:app_label": "ipam"
+            "!get:model": "prefix"
+    prefixes:
+      - "!get:prefix": "10.0.0.0/29"
+        "!ref": "server-prefix"
+    ip_addresses:
+      - "!next_available_ip":
+          prefix: "!ref:server-prefix"
+        mask_length: 30
+        parent: "!ref:server-prefix"
+        status__name: "Active"
+        tenant__name: "Nautobot Airports"
+      - "!next_available_ip":
+          prefix: "10.0.0.0/29"
+        parent: "!ref:server-prefix"
+        status__name: "Active"
+        tenant__name: "Nautobot Airports"
+checks:
+  - model_exists:
+      model: "nautobot.ipam.models.IPAddress"
+      query: {address: "10.0.0.2/29"}
+  - model_exists:
+      model: "nautobot.ipam.models.IPAddress"
+      query: {address: "10.0.0.3/29"}
+  - model_not_exist:
+      model: "nautobot.ipam.models.IPAddress"
+      query: {address: "10.0.0.4/29"}

--- a/nautobot_design_builder/contrib/tests/testdata/next_ip.yaml
+++ b/nautobot_design_builder/contrib/tests/testdata/next_ip.yaml
@@ -27,11 +27,11 @@ designs:
         "!ref": "server-prefix"
     ip_addresses:
       - "!next_ip":
-          parent: "!ref:server-prefix"
+          prefix: "!ref:server-prefix"
         status__name: "Active"
         tenant__name: "Nautobot Airports"
       - "!next_ip":
-          parent: "10.0.0.0/29"
+          prefix: "10.0.0.0/29"
         status__name: "Active"
         tenant__name: "Nautobot Airports"
 checks:

--- a/nautobot_design_builder/contrib/tests/testdata/next_ip.yaml
+++ b/nautobot_design_builder/contrib/tests/testdata/next_ip.yaml
@@ -26,11 +26,11 @@ designs:
       - "!get:prefix": "10.0.0.0/29"
         "!ref": "server-prefix"
     ip_addresses:
-      - "!next_available_ip":
+      - "!next_ip":
           parent: "!ref:server-prefix"
         status__name: "Active"
         tenant__name: "Nautobot Airports"
-      - "!next_available_ip":
+      - "!next_ip":
           parent: "10.0.0.0/29"
         status__name: "Active"
         tenant__name: "Nautobot Airports"


### PR DESCRIPTION
## What's Changed

Added a new action `!next_ip` which will calculate the next available ip address in the provided parent prefix.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
