### PR TITLE
fix: Fixes code injection vulnerability

### DIFF
--- a/changes/258.fixed
+++ b/changes/258.fixed
@@ -1,0 +1,1 @@
+Fixed code injection vulnerability

--- a/nautobot_design_builder/context.py
+++ b/nautobot_design_builder/context.py
@@ -270,6 +270,7 @@ def context_file(*ctx_files):
 
     return wrapper
 
+
 def sanitize_user_input(data: Any):
     """Prevent strings in the input from being converted to jinja templates."""
     if isinstance(data, str):
@@ -280,6 +281,7 @@ def sanitize_user_input(data: Any):
     elif isinstance(data, (list, UserList)):
         return [sanitize_user_input(item) for item in data]
     return data
+
 
 class Context(_DictNode):
     """A context represents a tree of variables that can include templates for values.

--- a/nautobot_design_builder/context.py
+++ b/nautobot_design_builder/context.py
@@ -276,9 +276,9 @@ def sanitize_user_input(data: Any):
     if isinstance(data, str):
         # This prevents `str` objects from being converted to `_TemplateNode`
         return UserString(data)
-    elif isinstance(data, Mapping):
+    if isinstance(data, Mapping):
         return {k: sanitize_user_input(v) for k, v in data.items()}
-    elif isinstance(data, (list, UserList)):
+    if isinstance(data, (list, UserList)):
         return [sanitize_user_input(item) for item in data]
     return data
 

--- a/nautobot_design_builder/context.py
+++ b/nautobot_design_builder/context.py
@@ -3,7 +3,7 @@
 import inspect
 from collections import UserDict, UserList, UserString
 from functools import cached_property
-from typing import Any
+from typing import Any, Mapping
 
 import yaml
 from jinja2.nativetypes import NativeEnvironment
@@ -270,6 +270,16 @@ def context_file(*ctx_files):
 
     return wrapper
 
+def sanitize_user_input(data: Any):
+    """Prevent strings in the input from being converted to jinja templates."""
+    if isinstance(data, str):
+        # This prevents `str` objects from being converted to `_TemplateNode`
+        return UserString(data)
+    elif isinstance(data, Mapping):
+        return {k: sanitize_user_input(v) for k, v in data.items()}
+    elif isinstance(data, (list, UserList)):
+        return [sanitize_user_input(item) for item in data]
+    return data
 
 class Context(_DictNode):
     """A context represents a tree of variables that can include templates for values.
@@ -297,8 +307,11 @@ class Context(_DictNode):
               or their native type.
     """
 
-    def __init__(self, data: dict = None, job_result: JobResult = None):
+    def __init__(self, data: dict = None, safe_load=False, job_result: JobResult = None):
         """Constructor for Context class that creates data nodes from input data."""
+        if safe_load and data is not None:
+            data = sanitize_user_input(data)
+
         super().__init__(data)
         self.job_result = job_result
 
@@ -336,15 +349,15 @@ class Context(_DictNode):
         return base
 
     @classmethod
-    def load(cls, yaml_or_mapping):
+    def load(cls, yaml_or_mapping, safe_load=False):
         """Load a context from a yaml file or mapping."""
         if isinstance(yaml_or_mapping, dict):
-            return cls(data=yaml_or_mapping)
+            return cls(data=yaml_or_mapping, safe_load=safe_load)
 
         if isinstance(yaml_or_mapping, list):
             raise ValueError("Can only load mappings or yaml")
 
-        return cls.load(yaml.safe_load(yaml_or_mapping))
+        return cls.load(yaml.safe_load(yaml_or_mapping), safe_load=safe_load)
 
     def validate(self):
         """Validate that the context can be used to render a design.

--- a/nautobot_design_builder/design_job.py
+++ b/nautobot_design_builder/design_job.py
@@ -294,7 +294,7 @@ class DesignJob(Job, ABC):  # pylint: disable=too-many-instance-attributes
         design_files = None
 
         if hasattr(self.Meta, "context_class"):
-            context = self.Meta.context_class(data=data, job_result=self.job_result)
+            context = self.Meta.context_class(data=data, safe_load=True, job_result=self.job_result)
             context.validate()
         else:
             context = {}

--- a/nautobot_design_builder/tests/test_context.py
+++ b/nautobot_design_builder/tests/test_context.py
@@ -49,8 +49,8 @@ class TestContext(unittest.TestCase):
         class PropertiesTest(Context):
             """Test class for context."""
 
-            def __init__(self, data):
-                super().__init__(data)
+            def __init__(self, data, **kwargs):
+                super().__init__(data, **kwargs)
                 self._my_prop = NestedPropertyClass()
 
             @property
@@ -77,6 +77,10 @@ class TestContext(unittest.TestCase):
     def test_nested_list(self):
         context = Context.load({"var1": {"var2": [True]}})
         self.assertTrue(context.var1["var2"][0])
+
+    def test_safe_load(self):
+        context = Context.load({"var1": "{{ True }}"}, safe_load=True)
+        self.assertEqual(context.var1, "{{ True }}")
 
 
 class TestUpdateDictNode(unittest.TestCase):


### PR DESCRIPTION
This change provides a way to prevent strings being evaluated as jinja2 templates. The change also sets the `Context` to not evaluate strings as templates. Since user input (script vars) are passed into the Context this will mean that they are not evaluated, but other strings provided in context files and context classes will still be evaluated is usual.

# Closes: #258

## To Do

- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation]
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
