### PR TITLE
Release v2.3.0

### DIFF
--- a/changes/+nautobot-app-v2-4-2.housekeeping
+++ b/changes/+nautobot-app-v2-4-2.housekeeping
@@ -1,1 +1,0 @@
-Align with Cookiecutter-Nautobot-App v2.4.2

--- a/changes/+nautobot-app-v2.5.0.housekeeping
+++ b/changes/+nautobot-app-v2.5.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.5.0`.

--- a/changes/+nautobot-app-v2.5.1.housekeeping
+++ b/changes/+nautobot-app-v2.5.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.5.1`.

--- a/changes/+nautobot-app-v2.6.0.housekeeping
+++ b/changes/+nautobot-app-v2.6.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.6.0`.

--- a/changes/+nautobot-app-v2.7.0.housekeeping
+++ b/changes/+nautobot-app-v2.7.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.0`.

--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/+nautobot-app-v2.7.2.housekeeping
+++ b/changes/+nautobot-app-v2.7.2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/changes/204.fixed
+++ b/changes/204.fixed
@@ -1,1 +1,0 @@
-Fixed problem creating rack reservations

--- a/changes/219.added
+++ b/changes/219.added
@@ -1,2 +1,0 @@
-Added a public testing framework by updating and moving DesignTestCase, BuilderChecks.
-Added to public testing framework by creating a small convenience method VerifyDesignTestCase.

--- a/changes/219.documentation
+++ b/changes/219.documentation
@@ -1,1 +1,0 @@
-Documented a public testing and checks framework.

--- a/changes/228.housekeeping
+++ b/changes/228.housekeeping
@@ -1,1 +1,0 @@
-Add Virtualization examples in tests

--- a/changes/244.housekeeping
+++ b/changes/244.housekeeping
@@ -1,1 +1,0 @@
-Implemented Component UI for detail views.

--- a/changes/253.housekeeping
+++ b/changes/253.housekeeping
@@ -1,1 +1,0 @@
-Backport #253 Fit&Finish to LTM-2.4

--- a/changes/566.housekeeping
+++ b/changes/566.housekeeping
@@ -1,1 +1,0 @@
-Pinned Django debug toolbar to <6.0.0.

--- a/docs/admin/release_notes/version_2.3.md
+++ b/docs/admin/release_notes/version_2.3.md
@@ -1,0 +1,38 @@
+# v2.3 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Changed minimum Nautobot version to 2.4.20.
+- Dropped support for Python versions 3.8 and 3.9.
+
+<!-- towncrier release notes start -->
+## [v2.3.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-design-builder/releases/tag/v2.3.0)
+
+### Added
+
+- [#219](https://github.com/nautobot/nautobot-app-design-builder/issues/219) - Added a public testing framework by updating and moving DesignTestCase, BuilderChecks.
+- [#219](https://github.com/nautobot/nautobot-app-design-builder/issues/219) - Added to public testing framework by creating a small convenience method VerifyDesignTestCase.
+
+### Fixed
+
+- [#204](https://github.com/nautobot/nautobot-app-design-builder/issues/204) - Fixed a problem when creating rack reservations.
+- [#253](https://github.com/nautobot/nautobot-app-design-builder/issues/253) - Fixed multiple search and filtering bugs.
+
+### Documentation
+
+- [#219](https://github.com/nautobot/nautobot-app-design-builder/issues/219) - Documented a public testing and checks framework.
+
+### Housekeeping
+
+- [#228](https://github.com/nautobot/nautobot-app-design-builder/issues/228) - Added Virtualization examples in tests.
+- [#244](https://github.com/nautobot/nautobot-app-design-builder/issues/244) - Implemented Component UI for detail views.
+- [#566](https://github.com/nautobot/nautobot-app-design-builder/issues/566) - Pinned Django debug toolbar to <6.0.0.
+- Rebaked from the cookie `nautobot-app-v2.4.2`.
+- Rebaked from the cookie `nautobot-app-v2.5.0`.
+- Rebaked from the cookie `nautobot-app-v2.5.1`.
+- Rebaked from the cookie `nautobot-app-v2.6.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.1`.
+- Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/docs/admin/release_notes/version_2.3.md
+++ b/docs/admin/release_notes/version_2.3.md
@@ -8,7 +8,7 @@ This document describes all new features and changes in the release. The format 
 - Dropped support for Python versions 3.8 and 3.9.
 
 <!-- towncrier release notes start -->
-## [v2.3.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-design-builder/releases/tag/v2.3.0)
+## [v2.3.0 (2025-12-09)](https://github.com/nautobot/nautobot-app-design-builder/releases/tag/v2.3.0)
 
 ### Added
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v2.3: "admin/release_notes/version_2.3.md"
           - v1.0: "admin/release_notes/version_1.0.md"
           - v1.1: "admin/release_notes/version_1.1.md"
           - v1.2: "admin/release_notes/version_1.2.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-design-builder"
-version = "2.3.0a0"
+version = "2.3.0"
 description = "Nautobot app that uses design templates to easily create data objects in Nautobot with minimal input from a user."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"
@@ -178,7 +178,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_design_builder"
 directory = "changes"
-filename = "docs/admin/release_notes/version_X.Y.md"
+filename = "docs/admin/release_notes/version_2.3.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-design-builder/issues/{issue})"


### PR DESCRIPTION
# v2.3 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Changed minimum Nautobot version to 2.4.20.
- Dropped support for Python versions 3.8 and 3.9.

## [v2.3.0 (2025-12-09)](https://github.com/nautobot/nautobot-app-design-builder/releases/tag/v2.3.0)

### Added

- [#219](https://github.com/nautobot/nautobot-app-design-builder/issues/219) - Added a public testing framework by updating and moving DesignTestCase, BuilderChecks.
- [#219](https://github.com/nautobot/nautobot-app-design-builder/issues/219) - Added to public testing framework by creating a small convenience method VerifyDesignTestCase.

### Fixed

- [#204](https://github.com/nautobot/nautobot-app-design-builder/issues/204) - Fixed a problem when creating rack reservations.
- [#253](https://github.com/nautobot/nautobot-app-design-builder/issues/253) - Fixed multiple search and filtering bugs.

### Documentation

- [#219](https://github.com/nautobot/nautobot-app-design-builder/issues/219) - Documented a public testing and checks framework.

### Housekeeping

- [#228](https://github.com/nautobot/nautobot-app-design-builder/issues/228) - Added Virtualization examples in tests.
- [#244](https://github.com/nautobot/nautobot-app-design-builder/issues/244) - Implemented Component UI for detail views.
- [#566](https://github.com/nautobot/nautobot-app-design-builder/issues/566) - Pinned Django debug toolbar to <6.0.0.
- Rebaked from the cookie `nautobot-app-v2.4.2`.
- Rebaked from the cookie `nautobot-app-v2.5.0`.
- Rebaked from the cookie `nautobot-app-v2.5.1`.
- Rebaked from the cookie `nautobot-app-v2.6.0`.
- Rebaked from the cookie `nautobot-app-v2.7.0`.
- Rebaked from the cookie `nautobot-app-v2.7.1`.
- Rebaked from the cookie `nautobot-app-v2.7.2`.
