### PR TITLE
Add panels to various models for Design Deployment membership

### DIFF
--- a/changes/270.added
+++ b/changes/270.added
@@ -1,0 +1,1 @@
+Added panels to various models to indicate Design Deployment membership.

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -1,7 +1,7 @@
 """Template content for nautobot_design_builder."""
 
 from django.conf import settings
-from django.utils.html import format_html
+from nautobot.apps.templatetags import hyperlinked_object as hyperlink
 from nautobot.apps.ui import (
     DataTablePanel,
     KeyValueTablePanel,
@@ -15,11 +15,6 @@ from nautobot.extras.utils import registry
 
 from nautobot_design_builder.models import ChangeRecord, Deployment
 from nautobot_design_builder.tables import DeploymentTable
-
-
-def linkify(deployment):
-    """Helper function to create an HTML link to a deployment."""
-    return format_html(f'<a href="{deployment.get_absolute_url()}">{deployment}</a>')
 
 
 class DesignBuilderTab(Tab):
@@ -46,7 +41,7 @@ class DesignObjectFieldsPanel(KeyValueTablePanel):
             "full_control": full_control_records.exists(),
         }
         if full_control_records.exists():
-            data.update({"owner_deployment": linkify(full_control_records.first().change_set.deployment)})
+            data.update({"owner_deployment": hyperlink(full_control_records.first().change_set.deployment)})
         context.update({"data": data})
         return super().should_render(context)
 
@@ -63,7 +58,7 @@ class AffectedAttributesPanel(DataTablePanel):
             .select_related("change_set__deployment")
         )
         affected_set = {(attr, record.change_set.deployment) for record in records for attr in record.changes}
-        affected_list = [{"attribute": attr, "deployment": linkify(deployment)} for attr, deployment in affected_set]
+        affected_list = [{"attribute": attr, "deployment": hyperlink(deployment)} for attr, deployment in affected_set]
         context.update({"affected_attributes": affected_list})
         return super().get_extra_context(context)
 

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -1,11 +1,19 @@
 """Template content for nautobot_design_builder."""
 
+from django.conf import settings
+from django.utils.html import format_html
+from nautobot.apps.templatetags import render_boolean
 from nautobot.apps.ui import DataTablePanel, ObjectsTablePanel, SectionChoices, Tab, TemplateExtension
 from nautobot.core.views.utils import get_obj_from_context
 from nautobot.extras.utils import registry
 
 from nautobot_design_builder.models import ChangeRecord, Deployment
 from nautobot_design_builder.tables import DeploymentTable
+
+
+def linkify(deployment):
+    """Helper function to create an HTML link to a deployment."""
+    return format_html(f'<a href="{deployment.get_absolute_url()}">{deployment}</a>')
 
 
 def tab_factory(content_type_label):
@@ -36,14 +44,20 @@ def tab_factory(content_type_label):
 
         def get_extra_context(self, context):
             obj = get_obj_from_context(context)
-            protected_attributes = [
-                {"attribute": attribute, "deployment": deployment}
-                for deployment in Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).distinct()
-                for record in ChangeRecord.objects.filter(
-                    _design_object_id=obj.pk, active=True, change_set__deployment=deployment
-                ).exclude_decommissioned()
-                for attribute in record.changes
-            ]
+            model = (obj._meta.app_label, obj._meta.model_name)
+            if model in settings.PLUGINS_CONFIG["nautobot_design_builder"]["protected_models"]:
+                records = ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True).exclude_decommissioned()
+                protected_attributes = [
+                    {
+                        "attribute": attribute,
+                        "deployment": linkify(record.change_set.deployment),
+                        "full_control": render_boolean(record.full_control),
+                    }
+                    for record in records
+                    for attribute in record.changes
+                ]
+            else:
+                protected_attributes = [{"attribute": "N/A", "deployment": "--- Model not protected ---"}]
             context.update({"protected_attributes": protected_attributes})
             return super().get_extra_context(context)
 
@@ -69,8 +83,8 @@ def tab_factory(content_type_label):
                         weight=200,
                         section=SectionChoices.FULL_WIDTH,
                         context_data_key="protected_attributes",
-                        columns=["attribute", "deployment"],
-                        column_headers=["Protected Attribute", "Controlling Deployment"],
+                        columns=["attribute", "deployment", "full_control"],
+                        column_headers=["Protected Attribute", "Controlling Deployment", "Full Control"],
                     ),
                 ],
             ),

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -7,7 +7,7 @@ from nautobot.apps.ui import ObjectsTablePanel, SectionChoices, TemplateExtensio
 from nautobot.core.views.utils import get_obj_from_context
 from nautobot.extras.utils import registry
 
-from nautobot_design_builder.models import ChangeRecord
+from nautobot_design_builder.models import Deployment
 from nautobot_design_builder.tables import DeploymentTable
 
 
@@ -18,8 +18,10 @@ class DeploymentObjectsTablePanel(ObjectsTablePanel):
         """Determine if the panel should be rendered based on the presence of data in context."""
         obj = get_obj_from_context(context)
         design_object_type = ContentType.objects.get_for_model(obj)
-        change_records = ChangeRecord.objects.filter(_design_object_id=obj.pk, _design_object_type=design_object_type)
-        parent_deployments = [change_record.change_set.deployment for change_record in change_records]
+
+        parent_deployments = Deployment.objects.filter(
+            change_sets__records___design_object_id=obj.pk, change_sets__records___design_object_type=design_object_type
+        ).distinct()
 
         if not parent_deployments:
             return False

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -1,12 +1,13 @@
 """Template content for nautobot_design_builder."""
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from nautobot.apps.ui import ObjectsTablePanel, SectionChoices, TemplateExtension
 from nautobot.core.views.utils import get_obj_from_context
 from nautobot.extras.utils import registry
 
-from nautobot_design_builder.models import Deployment
+from nautobot_design_builder.models import ChangeRecord
 from nautobot_design_builder.tables import DeploymentTable
 
 
@@ -16,16 +17,14 @@ class DeploymentObjectsTablePanel(ObjectsTablePanel):
     def should_render(self, context):
         """Determine if the panel should be rendered based on the presence of data in context."""
         obj = get_obj_from_context(context)
+        design_object_type = ContentType.objects.get_for_model(obj)
+        change_records = ChangeRecord.objects.filter(_design_object_id=obj.pk, _design_object_type=design_object_type)
+        parent_deployments = [change_record.change_set.deployment for change_record in change_records]
 
-        # Calculate parent deployments for the object
-        parent_deployments = []
-        for deployment in Deployment.objects.all():
-            if obj in deployment.get_design_objects(type(obj)):
-                parent_deployments.append(deployment)
+        if not parent_deployments:
+            return False
 
         parent_deployments_table = DeploymentTable(parent_deployments)
-
-        # Hide columns not in include_columns
         for column in parent_deployments_table.columns.all():
             if column.name not in self.include_columns:
                 parent_deployments_table.columns.hide(column.name)

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -1,9 +1,6 @@
 """Template content for nautobot_design_builder."""
 
-from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
-from nautobot.apps.ui import ObjectsTablePanel, SectionChoices, Tab, TemplateExtension
+from nautobot.apps.ui import DataTablePanel, ObjectsTablePanel, SectionChoices, Tab, TemplateExtension
 from nautobot.core.views.utils import get_obj_from_context
 from nautobot.extras.utils import registry
 
@@ -11,68 +8,75 @@ from nautobot_design_builder.models import ChangeRecord, Deployment
 from nautobot_design_builder.tables import DeploymentTable
 
 
-class DeploymentObjectsTablePanel(ObjectsTablePanel):
-    """DataTablePanel for displaying Deployment data."""
-
-    def should_render(self, context):
-        """Determine if the panel should be rendered based on the presence of data in context."""
-        obj = get_obj_from_context(context)
-        parent_deployments = Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).distinct()
-        parent_deployments_table = DeploymentTable(parent_deployments)
-        context.update({"parent_deployments": parent_deployments_table})
-        # return bool(parent_deployments)
-        return True
-
-
 def tab_factory(content_type_label):
     """Generate a Design Builder tab for a given content type."""
 
-    class DesignBuilderTab(TemplateExtension):  # pylint: disable=W0223
-        """Dynamically generated DesignBuilderTab class."""
+    class DesignBuilderTab(Tab):
+        """Custom Tab class to conditionally render based on parent deployment existence."""
+
+        def should_render(self, context):
+            """Render the tab only if deployments exist for the object."""
+            obj = get_obj_from_context(context)
+            if Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).exists():
+                return super().should_render(context)
+            return False
+
+    class ParentDeploymentsTablePanel(ObjectsTablePanel):
+        """DataTablePanel for displaying parent Deployments data."""
+
+        def get_extra_context(self, context):
+            obj = get_obj_from_context(context)
+            parent_deployments = Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).distinct()
+            parent_deployments_table = DeploymentTable(parent_deployments)
+            context.update({"parent_deployments": parent_deployments_table})
+            return super().get_extra_context(context)
+
+    class ProtectedAttributesPanel(DataTablePanel):
+        """ObjectsTablePanel for displaying protected attributes."""
+
+        def get_extra_context(self, context):
+            obj = get_obj_from_context(context)
+            protected_attributes = [
+                {"attribute": attribute, "deployment": deployment}
+                for deployment in Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).distinct()
+                for record in ChangeRecord.objects.filter(
+                    _design_object_id=obj.pk, active=True, change_set__deployment=deployment
+                ).exclude_decommissioned()
+                for attribute in record.changes
+            ]
+            context.update({"protected_attributes": protected_attributes})
+            return super().get_extra_context(context)
+
+    class DesignBuilderExtension(TemplateExtension):  # pylint: disable=abstract-method
+        """Dynamically generated DesignBuilderExtension class."""
 
         model = content_type_label
 
         object_detail_tabs = [
-            Tab(
+            DesignBuilderTab(
                 weight=100,
                 tab_id="design_builder_tab",
                 label="Design Builder",
                 panels=[
-                    DeploymentObjectsTablePanel(
+                    ParentDeploymentsTablePanel(
                         weight=100,
                         section=SectionChoices.FULL_WIDTH,
                         context_table_key="parent_deployments",
-                        table_title="Design Deployments containing this object",
-                        max_display_count=10,
+                        table_title="Design Deployments using this object",
                         paginate=True,
+                    ),
+                    ProtectedAttributesPanel(
+                        weight=200,
+                        section=SectionChoices.FULL_WIDTH,
+                        context_data_key="protected_attributes",
+                        columns=["attribute", "deployment"],
+                        column_headers=["Protected Attribute", "Controlling Deployment"],
                     ),
                 ],
             ),
         ]
 
-    return DesignBuilderTab
-
-
-# def tab_factory(content_type_label):
-#     """Generate a DataComplianceTab object for a given content type."""
-
-#     class DesignProtectionTab(TemplateExtension):  # pylint: disable=W0223
-#         """Dynamically generated DesignProtectionTab class."""
-
-#         model = content_type_label
-
-#         def detail_tabs(self):
-#             return [
-#                 {
-#                     "title": "Design Protection",
-#                     "url": reverse(
-#                         "plugins:nautobot_design_builder:design-protection-tab",
-#                         kwargs={"id": self.context["object"].id, "model": self.model},
-#                     ),
-#                 },
-#             ]
-
-#     return DesignProtectionTab
+    return DesignBuilderExtension
 
 
 class DesignBuilderTemplateIterator:  # pylint: disable=too-few-public-methods
@@ -83,8 +87,6 @@ class DesignBuilderTemplateIterator:  # pylint: disable=too-few-public-methods
         for app_label, models in registry["model_features"]["custom_validators"].items():
             for model in models:
                 yield tab_factory(f"{app_label}.{model}")
-                # if (app_label, model) in settings.PLUGINS_CONFIG["nautobot_design_builder"]["protected_models"]:
-                #     yield tab_factory(f"{app_label}.{model}")
 
 
 template_extensions = DesignBuilderTemplateIterator()

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -2,8 +2,58 @@
 
 from django.conf import settings
 from django.urls import reverse
-from nautobot.extras.plugins import TemplateExtension
+from nautobot.apps.ui import ObjectsTablePanel, SectionChoices, TemplateExtension
+from nautobot.core.views.utils import get_obj_from_context
 from nautobot.extras.utils import registry
+
+from nautobot_design_builder.models import Deployment
+from nautobot_design_builder.tables import DeploymentTable
+
+
+class DeploymentObjectsTablePanel(ObjectsTablePanel):
+    """DataTablePanel for displaying Deployment data."""
+
+    def should_render(self, context):
+        """Determine if the panel should be rendered based on the presence of data in context."""
+        obj = get_obj_from_context(context)
+
+        # Calculate parent deployments for the object
+        parent_deployments = []
+        for deployment in Deployment.objects.all():
+            if obj in deployment.get_design_objects(type(obj)):
+                parent_deployments.append(deployment)
+
+        parent_deployments_table = DeploymentTable(parent_deployments)
+
+        # Hide columns not in include_columns
+        for column in parent_deployments_table.columns.all():
+            if column.name not in self.include_columns:
+                parent_deployments_table.columns.hide(column.name)
+        context.update({"parent_deployments": parent_deployments_table})
+
+        return bool(parent_deployments)
+
+
+def table_factory(content_type_label):
+    """Generate a ObjectsTablePanel object for a given content type."""
+
+    class DesignDeploymentMembers(TemplateExtension):  # pylint: disable=W0223
+        """Dynamically generated DesignDeploymentMembers class."""
+
+        model = content_type_label
+
+        object_detail_panels = [
+            DeploymentObjectsTablePanel(
+                weight=100,
+                section=SectionChoices.LEFT_HALF,
+                context_table_key="parent_deployments",
+                include_columns=["name", "design", "version", "status"],
+                max_display_count=10,
+                paginate=True,
+            ),
+        ]
+
+    return DesignDeploymentMembers
 
 
 def tab_factory(content_type_label):
@@ -29,15 +79,15 @@ def tab_factory(content_type_label):
 
 
 class DesignBuilderTemplateIterator:  # pylint: disable=too-few-public-methods
-    """Iterator that generates CustomValidator classes for each model registered in the extras feature query registry 'custom_validators'."""
+    """Iterator that generates ObjectsTablePanel classes for all objects beloging to a Design Deployment."""
 
     def __iter__(self):
-        """Return a generator of CustomValidator classes for each registered model."""
+        """Return a generator of ObjectsTablePanel classes for each registered model."""
         for app_label, models in registry["model_features"]["custom_validators"].items():
             for model in models:
+                yield table_factory(f"{app_label}.{model}")
                 if (app_label, model) in settings.PLUGINS_CONFIG["nautobot_design_builder"]["protected_models"]:
-                    label = f"{app_label}.{model}"
-                    yield tab_factory(label)
+                    yield tab_factory(f"{app_label}.{model}")
 
 
 template_extensions = DesignBuilderTemplateIterator()

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -16,49 +16,56 @@ def linkify(deployment):
     return format_html(f'<a href="{deployment.get_absolute_url()}">{deployment}</a>')
 
 
+class DesignBuilderTab(Tab):
+    """Custom Tab class to conditionally render based on change record existence."""
+
+    def should_render(self, context):
+        """Render the tab only if change records exist for the object."""
+        obj = get_obj_from_context(context)
+        return ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True).exclude_decommissioned().exists()
+
+
+class ParentDeploymentsTablePanel(ObjectsTablePanel):
+    """DataTablePanel for displaying parent Deployments data."""
+
+    def get_extra_context(self, context):
+        """Add parent Deployments to the context."""
+        obj = get_obj_from_context(context)
+        parent_deployments = Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).distinct()
+        parent_deployments_table = DeploymentTable(parent_deployments)
+        context.update({"parent_deployments": parent_deployments_table})
+        return super().get_extra_context(context)
+
+
+class AffectedAttributesPanel(DataTablePanel):
+    """ObjectsTablePanel for displaying affected attributes."""
+
+    def get_extra_context(self, context):
+        """Add affected attributes to the context."""
+        obj = get_obj_from_context(context)
+        model = (obj._meta.app_label, obj._meta.model_name)
+        protected = model in settings.PLUGINS_CONFIG.get("nautobot_design_builder", {}).get("protected_models", [])
+        records = (
+            ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True)
+            .exclude_decommissioned()
+            .select_related("change_set__deployment")
+        )
+        affected_attributes = [
+            {
+                "attribute": attribute,
+                "deployment": linkify(record.change_set.deployment),
+                "protected": render_boolean(protected),
+                "full_control": render_boolean(record.full_control),
+            }
+            for record in records
+            for attribute in record.changes
+        ]
+        context.update({"affected_attributes": affected_attributes})
+        return super().get_extra_context(context)
+
+
 def tab_factory(content_type_label):
     """Generate a Design Builder tab for a given content type."""
-
-    class DesignBuilderTab(Tab):
-        """Custom Tab class to conditionally render based on parent deployment existence."""
-
-        def should_render(self, context):
-            """Render the tab only if deployments exist for the object."""
-            obj = get_obj_from_context(context)
-            if Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).exists():
-                return super().should_render(context)
-            return False
-
-    class ParentDeploymentsTablePanel(ObjectsTablePanel):
-        """DataTablePanel for displaying parent Deployments data."""
-
-        def get_extra_context(self, context):
-            obj = get_obj_from_context(context)
-            parent_deployments = Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).distinct()
-            parent_deployments_table = DeploymentTable(parent_deployments)
-            context.update({"parent_deployments": parent_deployments_table})
-            return super().get_extra_context(context)
-
-    class AffectedAttributesPanel(DataTablePanel):
-        """ObjectsTablePanel for displaying affected attributes."""
-
-        def get_extra_context(self, context):
-            obj = get_obj_from_context(context)
-            model = (obj._meta.app_label, obj._meta.model_name)
-            protected = model in settings.PLUGINS_CONFIG["nautobot_design_builder"]["protected_models"]
-            records = ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True).exclude_decommissioned()
-            affected_attributes = [
-                {
-                    "attribute": attribute,
-                    "deployment": linkify(record.change_set.deployment),
-                    "protected": render_boolean(protected),
-                    "full_control": render_boolean(record.full_control),
-                }
-                for record in records
-                for attribute in record.changes
-            ]
-            context.update({"affected_attributes": affected_attributes})
-            return super().get_extra_context(context)
 
     class DesignBuilderExtension(TemplateExtension):  # pylint: disable=abstract-method
         """Dynamically generated DesignBuilderExtension class."""
@@ -93,11 +100,11 @@ def tab_factory(content_type_label):
 
 
 class DesignBuilderTemplateIterator:  # pylint: disable=too-few-public-methods
-    """Iterator that generates ObjectsTablePanel classes for all objects beloging to a Design Deployment."""
+    """Iterator that generates ObjectsTablePanel classes for all objects belonging to a Design Deployment."""
 
     def __iter__(self):
         """Return a generator of ObjectsTablePanel classes for each registered model."""
-        for app_label, models in registry["model_features"]["custom_validators"].items():
+        for app_label, models in registry.get("model_features", {}).get("custom_validators", {}).items():
             for model in models:
                 yield tab_factory(f"{app_label}.{model}")
 

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -3,11 +3,11 @@
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-from nautobot.apps.ui import ObjectsTablePanel, SectionChoices, TemplateExtension
+from nautobot.apps.ui import ObjectsTablePanel, SectionChoices, Tab, TemplateExtension
 from nautobot.core.views.utils import get_obj_from_context
 from nautobot.extras.utils import registry
 
-from nautobot_design_builder.models import Deployment
+from nautobot_design_builder.models import ChangeRecord, Deployment
 from nautobot_design_builder.tables import DeploymentTable
 
 
@@ -17,66 +17,62 @@ class DeploymentObjectsTablePanel(ObjectsTablePanel):
     def should_render(self, context):
         """Determine if the panel should be rendered based on the presence of data in context."""
         obj = get_obj_from_context(context)
-        design_object_type = ContentType.objects.get_for_model(obj)
-
-        parent_deployments = Deployment.objects.filter(
-            change_sets__records___design_object_id=obj.pk, change_sets__records___design_object_type=design_object_type
-        ).distinct()
-
-        if not parent_deployments:
-            return False
-
+        parent_deployments = Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).distinct()
         parent_deployments_table = DeploymentTable(parent_deployments)
-        for column in parent_deployments_table.columns.all():
-            if column.name not in self.include_columns:
-                parent_deployments_table.columns.hide(column.name)
         context.update({"parent_deployments": parent_deployments_table})
-
-        return bool(parent_deployments)
-
-
-def table_factory(content_type_label):
-    """Generate a ObjectsTablePanel object for a given content type."""
-
-    class DesignDeploymentMembers(TemplateExtension):  # pylint: disable=W0223
-        """Dynamically generated DesignDeploymentMembers class."""
-
-        model = content_type_label
-
-        object_detail_panels = [
-            DeploymentObjectsTablePanel(
-                weight=100,
-                section=SectionChoices.LEFT_HALF,
-                context_table_key="parent_deployments",
-                include_columns=["name", "design", "version", "status"],
-                max_display_count=10,
-                paginate=True,
-            ),
-        ]
-
-    return DesignDeploymentMembers
+        # return bool(parent_deployments)
+        return True
 
 
 def tab_factory(content_type_label):
-    """Generate a DataComplianceTab object for a given content type."""
+    """Generate a Design Builder tab for a given content type."""
 
-    class DesignProtectionTab(TemplateExtension):  # pylint: disable=W0223
-        """Dynamically generated DesignProtectionTab class."""
+    class DesignBuilderTab(TemplateExtension):  # pylint: disable=W0223
+        """Dynamically generated DesignBuilderTab class."""
 
         model = content_type_label
 
-        def detail_tabs(self):
-            return [
-                {
-                    "title": "Design Protection",
-                    "url": reverse(
-                        "plugins:nautobot_design_builder:design-protection-tab",
-                        kwargs={"id": self.context["object"].id, "model": self.model},
+        object_detail_tabs = [
+            Tab(
+                weight=100,
+                tab_id="design_builder_tab",
+                label="Design Builder",
+                panels=[
+                    DeploymentObjectsTablePanel(
+                        weight=100,
+                        section=SectionChoices.FULL_WIDTH,
+                        context_table_key="parent_deployments",
+                        table_title="Design Deployments containing this object",
+                        max_display_count=10,
+                        paginate=True,
                     ),
-                },
-            ]
+                ],
+            ),
+        ]
 
-    return DesignProtectionTab
+    return DesignBuilderTab
+
+
+# def tab_factory(content_type_label):
+#     """Generate a DataComplianceTab object for a given content type."""
+
+#     class DesignProtectionTab(TemplateExtension):  # pylint: disable=W0223
+#         """Dynamically generated DesignProtectionTab class."""
+
+#         model = content_type_label
+
+#         def detail_tabs(self):
+#             return [
+#                 {
+#                     "title": "Design Protection",
+#                     "url": reverse(
+#                         "plugins:nautobot_design_builder:design-protection-tab",
+#                         kwargs={"id": self.context["object"].id, "model": self.model},
+#                     ),
+#                 },
+#             ]
+
+#     return DesignProtectionTab
 
 
 class DesignBuilderTemplateIterator:  # pylint: disable=too-few-public-methods
@@ -86,9 +82,9 @@ class DesignBuilderTemplateIterator:  # pylint: disable=too-few-public-methods
         """Return a generator of ObjectsTablePanel classes for each registered model."""
         for app_label, models in registry["model_features"]["custom_validators"].items():
             for model in models:
-                yield table_factory(f"{app_label}.{model}")
-                if (app_label, model) in settings.PLUGINS_CONFIG["nautobot_design_builder"]["protected_models"]:
-                    yield tab_factory(f"{app_label}.{model}")
+                yield tab_factory(f"{app_label}.{model}")
+                # if (app_label, model) in settings.PLUGINS_CONFIG["nautobot_design_builder"]["protected_models"]:
+                #     yield tab_factory(f"{app_label}.{model}")
 
 
 template_extensions = DesignBuilderTemplateIterator()

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -2,8 +2,14 @@
 
 from django.conf import settings
 from django.utils.html import format_html
-from nautobot.apps.templatetags import render_boolean
-from nautobot.apps.ui import DataTablePanel, ObjectsTablePanel, SectionChoices, Tab, TemplateExtension
+from nautobot.apps.ui import (
+    DataTablePanel,
+    KeyValueTablePanel,
+    ObjectsTablePanel,
+    SectionChoices,
+    Tab,
+    TemplateExtension,
+)
 from nautobot.core.views.utils import get_obj_from_context
 from nautobot.extras.utils import registry
 
@@ -25,6 +31,43 @@ class DesignBuilderTab(Tab):
         return ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True).exclude_decommissioned().exists()
 
 
+class DesignObjectFieldsPanel(KeyValueTablePanel):
+    """Design-related fields for the object."""
+
+    def should_render(self, context):
+        """Only render if the object is part of an active change record."""
+        obj = get_obj_from_context(context)
+        model = (obj._meta.app_label, obj._meta.model_name)
+        is_protected = model in settings.PLUGINS_CONFIG.get("nautobot_design_builder", {}).get("protected_models", [])
+        full_control_records = ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True, full_control=True)
+        data = {
+            "type": f"{obj._meta.app_label}.{obj._meta.model_name}",
+            "protected": is_protected,
+            "full_control": full_control_records.exists(),
+        }
+        if full_control_records.exists():
+            data.update({"owner_deployment": linkify(full_control_records.first().change_set.deployment)})
+        context.update({"data": data})
+        return super().should_render(context)
+
+
+class AffectedAttributesPanel(DataTablePanel):
+    """ObjectsTablePanel for displaying affected attributes."""
+
+    def get_extra_context(self, context):
+        """Add affected attributes to the context."""
+        obj = get_obj_from_context(context)
+        records = (
+            ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True)
+            .exclude_decommissioned()
+            .select_related("change_set__deployment")
+        )
+        affected_set = {(attr, record.change_set.deployment) for record in records for attr in record.changes}
+        affected_list = [{"attribute": attr, "deployment": linkify(deployment)} for attr, deployment in affected_set]
+        context.update({"affected_attributes": affected_list})
+        return super().get_extra_context(context)
+
+
 class ParentDeploymentsTablePanel(ObjectsTablePanel):
     """DataTablePanel for displaying parent Deployments data."""
 
@@ -34,33 +77,6 @@ class ParentDeploymentsTablePanel(ObjectsTablePanel):
         parent_deployments = Deployment.objects.filter(change_sets__records___design_object_id=obj.pk).distinct()
         parent_deployments_table = DeploymentTable(parent_deployments)
         context.update({"parent_deployments": parent_deployments_table})
-        return super().get_extra_context(context)
-
-
-class AffectedAttributesPanel(DataTablePanel):
-    """ObjectsTablePanel for displaying affected attributes."""
-
-    def get_extra_context(self, context):
-        """Add affected attributes to the context."""
-        obj = get_obj_from_context(context)
-        model = (obj._meta.app_label, obj._meta.model_name)
-        protected = model in settings.PLUGINS_CONFIG.get("nautobot_design_builder", {}).get("protected_models", [])
-        records = (
-            ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True)
-            .exclude_decommissioned()
-            .select_related("change_set__deployment")
-        )
-        affected_attributes = [
-            {
-                "attribute": attribute,
-                "deployment": linkify(record.change_set.deployment),
-                "protected": render_boolean(protected),
-                "full_control": render_boolean(record.full_control),
-            }
-            for record in records
-            for attribute in record.changes
-        ]
-        context.update({"affected_attributes": affected_attributes})
         return super().get_extra_context(context)
 
 
@@ -78,19 +94,25 @@ def tab_factory(content_type_label):
                 tab_id="design_builder_tab",
                 label="Design Builder",
                 panels=[
-                    ParentDeploymentsTablePanel(
+                    DesignObjectFieldsPanel(
                         weight=100,
+                        section=SectionChoices.LEFT_HALF,
+                        label="Data Protection",
+                        context_data_key="data",
+                    ),
+                    AffectedAttributesPanel(
+                        weight=200,
+                        section=SectionChoices.RIGHT_HALF,
+                        context_data_key="affected_attributes",
+                        columns=["attribute", "deployment"],
+                        column_headers=["Attribute", "Controlling Design Deployment"],
+                    ),
+                    ParentDeploymentsTablePanel(
+                        weight=300,
                         section=SectionChoices.FULL_WIDTH,
                         context_table_key="parent_deployments",
                         table_title="Design Deployments using this object",
                         paginate=True,
-                    ),
-                    AffectedAttributesPanel(
-                        weight=200,
-                        section=SectionChoices.FULL_WIDTH,
-                        context_data_key="affected_attributes",
-                        columns=["attribute", "deployment", "protected", "full_control"],
-                        column_headers=["Attribute", "Controlling Design Deployment", "Protected", "Full Control"],
                     ),
                 ],
             ),

--- a/nautobot_design_builder/template_content.py
+++ b/nautobot_design_builder/template_content.py
@@ -39,26 +39,25 @@ def tab_factory(content_type_label):
             context.update({"parent_deployments": parent_deployments_table})
             return super().get_extra_context(context)
 
-    class ProtectedAttributesPanel(DataTablePanel):
-        """ObjectsTablePanel for displaying protected attributes."""
+    class AffectedAttributesPanel(DataTablePanel):
+        """ObjectsTablePanel for displaying affected attributes."""
 
         def get_extra_context(self, context):
             obj = get_obj_from_context(context)
             model = (obj._meta.app_label, obj._meta.model_name)
-            if model in settings.PLUGINS_CONFIG["nautobot_design_builder"]["protected_models"]:
-                records = ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True).exclude_decommissioned()
-                protected_attributes = [
-                    {
-                        "attribute": attribute,
-                        "deployment": linkify(record.change_set.deployment),
-                        "full_control": render_boolean(record.full_control),
-                    }
-                    for record in records
-                    for attribute in record.changes
-                ]
-            else:
-                protected_attributes = [{"attribute": "N/A", "deployment": "--- Model not protected ---"}]
-            context.update({"protected_attributes": protected_attributes})
+            protected = model in settings.PLUGINS_CONFIG["nautobot_design_builder"]["protected_models"]
+            records = ChangeRecord.objects.filter(_design_object_id=obj.pk, active=True).exclude_decommissioned()
+            affected_attributes = [
+                {
+                    "attribute": attribute,
+                    "deployment": linkify(record.change_set.deployment),
+                    "protected": render_boolean(protected),
+                    "full_control": render_boolean(record.full_control),
+                }
+                for record in records
+                for attribute in record.changes
+            ]
+            context.update({"affected_attributes": affected_attributes})
             return super().get_extra_context(context)
 
     class DesignBuilderExtension(TemplateExtension):  # pylint: disable=abstract-method
@@ -79,12 +78,12 @@ def tab_factory(content_type_label):
                         table_title="Design Deployments using this object",
                         paginate=True,
                     ),
-                    ProtectedAttributesPanel(
+                    AffectedAttributesPanel(
                         weight=200,
                         section=SectionChoices.FULL_WIDTH,
-                        context_data_key="protected_attributes",
-                        columns=["attribute", "deployment", "full_control"],
-                        column_headers=["Protected Attribute", "Controlling Deployment", "Full Control"],
+                        context_data_key="affected_attributes",
+                        columns=["attribute", "deployment", "protected", "full_control"],
+                        column_headers=["Attribute", "Controlling Design Deployment", "Protected", "Full Control"],
                     ),
                 ],
             ),

--- a/nautobot_design_builder/urls.py
+++ b/nautobot_design_builder/urls.py
@@ -9,7 +9,6 @@ from nautobot_design_builder.views import (
     ChangeRecordUIViewSet,
     ChangeSetUIViewSet,
     DeploymentUIViewSet,
-    DesignProtectionObjectView,
     DesignUIViewSet,
 )
 
@@ -21,13 +20,6 @@ router.register("change-sets", ChangeSetUIViewSet)
 router.register("change-records", ChangeRecordUIViewSet)
 
 
-urlpatterns = [
-    path("docs/", RedirectView.as_view(url=static("nautobot_design_builder/docs/index.html")), name="docs"),
-    path(
-        "design-protection/<model>/<uuid:id>/",
-        DesignProtectionObjectView.as_view(),
-        name="design-protection-tab",
-    ),
-]
+urlpatterns = [path("docs/", RedirectView.as_view(url=static("nautobot_design_builder/docs/index.html")), name="docs")]
 
 urlpatterns += router.urls

--- a/nautobot_design_builder/views.py
+++ b/nautobot_design_builder/views.py
@@ -1,12 +1,9 @@
 """UI Views for design builder."""
 
-from django.apps import apps as global_apps
-from django.core.exceptions import FieldDoesNotExist
 from django.shortcuts import render
 from nautobot.apps.models import count_related
 from nautobot.apps.ui import ObjectDetailContent, ObjectFieldsPanel, ObjectsTablePanel, ObjectTextPanel, SectionChoices
 from nautobot.apps.views import get_obj_from_context
-from nautobot.core.views.generic import ObjectView
 from nautobot.core.views.mixins import (
     PERMISSIONS_ACTION_MAP,
     ObjectChangeLogViewMixin,
@@ -296,40 +293,3 @@ class ChangeRecordUIViewSet(  # pylint:disable=abstract-method
             ),
         ),
     )
-
-
-class DesignProtectionObjectView(ObjectView):
-    """View for the Audit Results tab dynamically generated on specific object detail views."""
-
-    template_name = "nautobot_design_builder/designprotection_tab.html"
-
-    def dispatch(self, request, *args, **kwargs):
-        """Set the queryset for the given object and call the inherited dispatch method."""
-        model = kwargs.pop("model")
-        if not self.queryset:
-            self.queryset = global_apps.get_model(model).objects.all()
-        return super().dispatch(request, *args, **kwargs)
-
-    def get_extra_context(self, request, instance):
-        """Generate extra context for rendering the DesignProtection template."""
-        content = {}
-
-        records = models.ChangeRecord.objects.filter(
-            _design_object_id=instance.id, active=True
-        ).exclude_decommissioned()
-
-        if records:
-            design_owner = records.filter(full_control=True, _design_object_id=instance.pk)
-            if design_owner:
-                content["object"] = design_owner.first().change_set.deployment
-            for record in records:
-                for attribute in record.changes:
-                    try:
-                        field = instance._meta.get_field(attribute)
-                        content[field.name] = record.change_set.deployment
-                    except FieldDoesNotExist:
-                        # TODO: should this be logged? I can't think of when we would care
-                        # that a model's fields have changed since a design was implemented
-                        pass
-
-        return {"active_tab": request.GET["tab"], "design_protection": content}


### PR DESCRIPTION
## Closes: #270 #167 

## What's Changed
Dynamically adds "Design Builder" tabs to the various models to indicate Design Deployment membership, affected attributes, and their protection levels. Tabs are conditional and only render when the object "belongs" to a Design Deployment.
<img width="1545" height="479" alt="image" src="https://github.com/user-attachments/assets/8e7e8398-b2a3-402e-8c2f-44af16b4c927" />
<img width="1537" height="482" alt="image" src="https://github.com/user-attachments/assets/b89a6d01-fa92-4819-957a-6cd625097742" />


## To Do
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
