### PR TITLE
Revise getting started guide for Design Builder

### DIFF
--- a/docs/user/app_getting_started.md
+++ b/docs/user/app_getting_started.md
@@ -8,14 +8,9 @@ To install the App, please follow the instructions detailed in the [Installation
 
 ## First steps with the App
 
-The easiest way to experience Design Builder is to either add the [demo-designs](https://github.com/nautobot/demo-designs) as a git data source in an existing Nautobot environment, or to clone that repository and run it in a local environment. To start a local environment, clone the [demo-designs](https://github.com/nautobot/demo-designs) git repository and start the application stack. The only requirements for starting a local environment are `docker`, `docker-compose` and [invoke](https://www.pyinvoke.org/installing.html). Once the dependent tools have been installed you'll need to build the docker image by running `invoke build`. At that point, simply run the command `invoke start`. This will start the entire application stack using docker compose. Once the application stack is up and running, navigate to <http://127.0.0.1:8080/> and login. By default, the application stack will use Nautobot version 1.6. To see design builder in Nautobot 2, copy the `invoke.nautobot_2.yml` to `invoke.yml` and restart the application stack.
-
-## What are the next steps?
-
-<!-- TODO: update with the new Design Navigation and new screenshoots -->
+The easiest way to experience Design Builder is to either add the [demo-designs](https://github.com/nautobot/demo-designs) as a git data source in an existing Nautobot environment, or in your local [development environment](../dev/dev_environment.md). 
 
 The Design Builder demo designs ship with some sample designs to demonstrate capabilities. Once the application stack is ready, you should have several jobs listed under the "Jobs" -> "Jobs" menu item.
-
 
 <!-- updated-images -->
 ![Jobs list](../images/screenshots/sample-design-jobs-list-light.png#only-light){ .on-glb }
@@ -27,15 +22,12 @@ Note that the jobs are disabled. Nautobot automatically marks jobs as disabled w
 ![enabled checkbox](../images/screenshots/job-enabled-checkbox-light.png#only-light){ .on-glb }
 ![enabled checkbox](../images/screenshots/job-enabled-checkbox-dark.png#only-dark){ .on-glb }
 
-
 Once you click `save`, the jobs should be runnable.
 
 To implement any design, click the run button ![run button](../images/screenshots/run-button-light.png#only-light){ .on-glb }![run button](../images/screenshots/run-button-dark.png#only-dark){ .on-glb }. For example, run the "Initial Data" job, which will add a manufacturer, a device type, a device role, several regions and several sites. Additionally, each site will have two devices. If you run the job you should see output in the job result that shows the various objects being created:
 
-
 <!-- updated-images -->
 ![design job result](../images/screenshots/design-job-result-light.png#only-light){ .on-glb }
 ![design job result](../images/screenshots/design-job-result-dark.png#only-dark){ .on-glb }
-
 
 Once the initial data job has been run, try enabling and running the "Backbone Site Design" job to create a new site with racks and routers.


### PR DESCRIPTION
Removed outdated getting started steps that address developers and refer to 1.6/2.0.


