### PR TITLE
fix ChangeRecord.design_object API serializer not respecting the depth property.

### DIFF
--- a/changes/298.fixed
+++ b/changes/298.fixed
@@ -1,0 +1,1 @@
+Fixed ChangeRecord.design_object API serializer not respecting the depth property.

--- a/nautobot_design_builder/api/serializers.py
+++ b/nautobot_design_builder/api/serializers.py
@@ -2,10 +2,17 @@
 
 from django.contrib.contenttypes.models import ContentType
 from drf_spectacular.utils import extend_schema_field
-from nautobot.apps.api import NautobotModelSerializer, TaggedModelSerializerMixin
+from nautobot.apps.api import (
+    NautobotModelSerializer,
+    TaggedModelSerializerMixin,
+)
+from nautobot.apps.exceptions import SerializerNotFound
 from nautobot.core.api import ContentTypeField
-from nautobot.core.api.utils import get_serializer_for_model
-from rest_framework.fields import DictField, SerializerMethodField
+from nautobot.core.api.utils import (
+    get_nested_serializer_depth,
+    return_nested_serializer_data_based_on_depth,
+)
+from rest_framework.fields import SerializerMethodField
 from rest_framework.serializers import ReadOnlyField
 
 from nautobot_design_builder.models import ChangeRecord, ChangeSet, Deployment, Design
@@ -66,11 +73,15 @@ class ChangeRecordSerializer(NautobotModelSerializer):
         model = ChangeRecord
         fields = "__all__"
 
-    @extend_schema_field(DictField())
+    @extend_schema_field({"type": "object", "nullable": True})
     def get_design_object(self, obj):
         """Get design object serialized."""
         if obj.design_object:
-            serializer = get_serializer_for_model(obj.design_object)
-            context = {"request": self.context["request"]}
-            return serializer(obj.design_object, context=context).data
+            try:
+                depth = get_nested_serializer_depth(self)
+                return return_nested_serializer_data_based_on_depth(
+                    self, depth, obj, obj.design_object, "design_object"
+                )
+            except SerializerNotFound:
+                return None
         return None


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: NAPPS-1485
## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
